### PR TITLE
Incremental routing code refactoring (1)

### DIFF
--- a/commons/zenoh-protocol-core/src/encoding.rs
+++ b/commons/zenoh-protocol-core/src/encoding.rs
@@ -172,7 +172,7 @@ impl From<&'static str> for Encoding {
     }
 }
 
-impl<'a> From<String> for Encoding {
+impl From<String> for Encoding {
     fn from(s: String) -> Self {
         for (i, v) in consts::MIMES.iter().enumerate() {
             if i != 0 && s.starts_with(v) {

--- a/commons/zenoh-protocol-core/src/lib.rs
+++ b/commons/zenoh-protocol-core/src/lib.rs
@@ -33,7 +33,7 @@ pub type NonZeroZInt = NonZeroU64;
 pub const ZINT_MAX_BYTES: usize = 10;
 
 // WhatAmI values
-pub type WhatAmI = whatami::WhatAmI;
+pub use whatami::WhatAmI;
 
 /// Constants and helpers for zenoh `whatami` flags.
 pub mod whatami;
@@ -54,14 +54,14 @@ pub use locators::Locator;
 pub mod endpoints;
 pub use endpoints::EndPoint;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Property {
     pub key: ZInt,
     pub value: Vec<u8>,
 }
 
 /// The global unique id of a zenoh peer.
-#[derive(Clone, Copy, Eq)]
+#[derive(Clone, Copy)]
 pub struct PeerId {
     size: usize,
     id: [u8; PeerId::MAX_SIZE],
@@ -119,9 +119,11 @@ impl FromStr for PeerId {
 impl PartialEq for PeerId {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.size == other.size && self.as_slice() == other.as_slice()
+        self.as_slice() == other.as_slice()
     }
 }
+
+impl Eq for PeerId {}
 
 impl Hash for PeerId {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -148,7 +150,7 @@ impl From<&PeerId> for uhlc::ID {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum Priority {
     Control = 0,
@@ -170,6 +172,7 @@ impl Default for Priority {
         Priority::Data
     }
 }
+
 impl TryFrom<u8> for Priority {
     type Error = zenoh_core::Error;
 
@@ -191,7 +194,7 @@ impl TryFrom<u8> for Priority {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum Reliability {
     BestEffort,
@@ -204,13 +207,13 @@ impl Default for Reliability {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 pub struct Channel {
     pub priority: Priority,
     pub reliability: Reliability,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ConduitSnList {
     Plain(ConduitSn),
     QoS(Box<[ConduitSn; Priority::NUM]>),
@@ -248,14 +251,14 @@ impl fmt::Display for ConduitSnList {
 }
 
 /// The kind of reliability.
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 pub struct ConduitSn {
     pub reliable: ZInt,
     pub best_effort: ZInt,
 }
 
 /// The kind of congestion control.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum CongestionControl {
     Block,
@@ -269,7 +272,7 @@ impl Default for CongestionControl {
 }
 
 /// The subscription mode.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum SubMode {
     Push,
@@ -284,21 +287,21 @@ impl Default for SubMode {
 }
 
 /// A time period.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Period {
     pub origin: ZInt,
     pub period: ZInt,
     pub duration: ZInt,
 }
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct SubInfo {
     pub reliability: Reliability,
     pub mode: SubMode,
     pub period: Option<Period>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct QueryableInfo {
     pub complete: ZInt,
     pub distance: ZInt,
@@ -320,7 +323,7 @@ pub mod queryable {
 }
 
 /// The kind of consolidation.
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Eq, Hash)]
 #[repr(u8)]
 pub enum ConsolidationMode {
     None,
@@ -330,7 +333,7 @@ pub enum ConsolidationMode {
 
 /// The kind of consolidation that should be applied on replies to a [`get`](zenoh::Session::get)
 /// at different stages of the reply process.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ConsolidationStrategy {
     pub first_routers: ConsolidationMode,
     pub last_router: ConsolidationMode,
@@ -415,7 +418,7 @@ impl Default for ConsolidationStrategy {
 }
 
 /// The [`Queryable`](zenoh::queryable::Queryable)s that should be target of a [`get`](zenoh::Session::get).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Target {
     BestMatching,
     All,
@@ -432,7 +435,7 @@ impl Default for Target {
 }
 
 /// The [`Queryable`](zenoh::queryable::Queryable)s that should be target of a [`get`](zenoh::Session::get).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct QueryTarget {
     pub kind: ZInt,
     pub target: Target,

--- a/io/zenoh-transport/src/primitives/mod.rs
+++ b/io/zenoh-transport/src/primitives/mod.rs
@@ -23,6 +23,7 @@ use super::protocol::io::ZBuf;
 use super::protocol::proto::{DataInfo, RoutingContext};
 pub use demux::*;
 pub use mux::*;
+use std::ops::Deref;
 
 pub trait Primitives: Send + Sync {
     fn decl_resource(&self, expr_id: ZInt, key_expr: &KeyExpr);
@@ -94,6 +95,133 @@ pub trait Primitives: Send + Sync {
     );
 
     fn send_close(&self);
+}
+
+impl<P> Primitives for P
+where
+    P: Deref + Send + Sync,
+    P::Target: Primitives + Send + Sync,
+{
+    fn decl_resource(&self, expr_id: ZInt, key_expr: &KeyExpr) {
+        self.deref().decl_resource(expr_id, key_expr)
+    }
+
+    fn forget_resource(&self, expr_id: ZInt) {
+        self.deref().forget_resource(expr_id)
+    }
+
+    fn decl_publisher(&self, key_expr: &KeyExpr, routing_context: Option<RoutingContext>) {
+        self.deref().decl_publisher(key_expr, routing_context)
+    }
+
+    fn forget_publisher(&self, key_expr: &KeyExpr, routing_context: Option<RoutingContext>) {
+        self.deref().forget_publisher(key_expr, routing_context)
+    }
+
+    fn decl_subscriber(
+        &self,
+        key_expr: &KeyExpr,
+        sub_info: &SubInfo,
+        routing_context: Option<RoutingContext>,
+    ) {
+        self.deref()
+            .decl_subscriber(key_expr, sub_info, routing_context)
+    }
+
+    fn forget_subscriber(&self, key_expr: &KeyExpr, routing_context: Option<RoutingContext>) {
+        self.deref().forget_subscriber(key_expr, routing_context)
+    }
+
+    fn decl_queryable(
+        &self,
+        key_expr: &KeyExpr,
+        kind: ZInt,
+        qabl_info: &QueryableInfo,
+        routing_context: Option<RoutingContext>,
+    ) {
+        self.deref()
+            .decl_queryable(key_expr, kind, qabl_info, routing_context)
+    }
+
+    fn forget_queryable(
+        &self,
+        key_expr: &KeyExpr,
+        kind: ZInt,
+        routing_context: Option<RoutingContext>,
+    ) {
+        self.deref()
+            .forget_queryable(key_expr, kind, routing_context)
+    }
+
+    fn send_data(
+        &self,
+        key_expr: &KeyExpr,
+        payload: ZBuf,
+        channel: Channel,
+        cogestion_control: CongestionControl,
+        data_info: Option<DataInfo>,
+        routing_context: Option<RoutingContext>,
+    ) {
+        self.deref().send_data(
+            key_expr,
+            payload,
+            channel,
+            cogestion_control,
+            data_info,
+            routing_context,
+        )
+    }
+
+    fn send_query(
+        &self,
+        key_expr: &KeyExpr,
+        value_selector: &str,
+        qid: ZInt,
+        target: QueryTarget,
+        consolidation: ConsolidationStrategy,
+        routing_context: Option<RoutingContext>,
+    ) {
+        self.deref().send_query(
+            key_expr,
+            value_selector,
+            qid,
+            target,
+            consolidation,
+            routing_context,
+        )
+    }
+
+    fn send_reply_data(
+        &self,
+        qid: ZInt,
+        replier_kind: ZInt,
+        replier_id: PeerId,
+        key_expr: KeyExpr,
+        info: Option<DataInfo>,
+        payload: ZBuf,
+    ) {
+        self.deref()
+            .send_reply_data(qid, replier_kind, replier_id, key_expr, info, payload)
+    }
+
+    fn send_reply_final(&self, qid: ZInt) {
+        self.deref().send_reply_final(qid)
+    }
+
+    fn send_pull(
+        &self,
+        is_final: bool,
+        key_expr: &KeyExpr,
+        pull_id: ZInt,
+        max_samples: &Option<ZInt>,
+    ) {
+        self.deref()
+            .send_pull(is_final, key_expr, pull_id, max_samples)
+    }
+
+    fn send_close(&self) {
+        self.deref().send_close()
+    }
 }
 
 #[derive(Default)]

--- a/zenoh/src/net/routing/face.rs
+++ b/zenoh/src/net/routing/face.rs
@@ -11,6 +11,7 @@
 // Contributors:
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
+use super::network::LinkId;
 use super::router::*;
 use async_std::sync::Arc;
 use std::collections::{HashMap, HashSet};
@@ -45,7 +46,7 @@ pub struct FaceState {
     pub(super) pid: PeerId,
     pub(super) whatami: WhatAmI,
     pub(super) primitives: Arc<dyn Primitives + Send + Sync>,
-    pub(super) link_id: usize,
+    pub(super) link_id: LinkId,
     pub(super) local_mappings: HashMap<ZInt, ResourceTreeIndex>,
     pub(super) remote_mappings: HashMap<ZInt, ResourceTreeIndex>,
     pub(super) local_subs: HashSet<ResourceTreeIndex>,
@@ -62,7 +63,7 @@ impl FaceState {
         pid: PeerId,
         whatami: WhatAmI,
         primitives: Arc<dyn Primitives + Send + Sync>,
-        link_id: usize,
+        link_id: LinkId,
     ) -> Arc<FaceState> {
         Arc::new(FaceState {
             id,

--- a/zenoh/src/net/routing/face.rs
+++ b/zenoh/src/net/routing/face.rs
@@ -174,7 +174,6 @@ impl fmt::Display for FaceState {
     }
 }
 
-#[derive(Clone)]
 pub struct Face {
     pub(crate) tables: Arc<RwLock<Tables>>,
     pub(crate) state: Arc<FaceState>,

--- a/zenoh/src/net/routing/face.rs
+++ b/zenoh/src/net/routing/face.rs
@@ -24,8 +24,24 @@ use zenoh_protocol_core::{
 };
 use zenoh_transport::Primitives;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct FaceId(usize);
+
+impl FaceId {
+    pub fn new(id: usize) -> Self {
+        Self(id)
+    }
+}
+
+impl fmt::Display for FaceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 pub struct FaceState {
-    pub(super) id: usize,
+    pub(super) id: FaceId,
     pub(super) pid: PeerId,
     pub(super) whatami: WhatAmI,
     pub(super) primitives: Arc<dyn Primitives + Send + Sync>,
@@ -42,7 +58,7 @@ pub struct FaceState {
 
 impl FaceState {
     pub(super) fn new(
-        id: usize,
+        id: FaceId,
         pid: PeerId,
         whatami: WhatAmI,
         primitives: Arc<dyn Primitives + Send + Sync>,

--- a/zenoh/src/net/routing/network.rs
+++ b/zenoh/src/net/routing/network.rs
@@ -13,7 +13,8 @@
 //
 use super::runtime::Runtime;
 use petgraph::graph::NodeIndex;
-use petgraph::visit::{IntoNodeReferences, VisitMap, Visitable};
+use petgraph::visit::{VisitMap, Visitable};
+use std::collections::HashSet;
 use std::convert::TryInto;
 use std::fmt;
 use vec_map::VecMap;
@@ -755,17 +756,12 @@ impl Network {
 
         new_childs
     }
-}
 
-#[inline]
-pub(super) fn shared_nodes(net1: &Network, net2: &Network) -> Vec<PeerId> {
-    net1.graph
-        .node_references()
-        .filter_map(|(_, node1)| {
-            net2.graph
-                .node_references()
-                .any(|(_, node2)| node1.pid == node2.pid)
-                .then(|| node1.pid)
-        })
-        .collect()
+    #[inline]
+    pub(super) fn shared_nodes(&self, other: &Network) -> Vec<PeerId> {
+        let pid_set1: HashSet<_> = self.graph.node_weights().map(|node| node.pid).collect();
+        let pid_set2: HashSet<_> = other.graph.node_weights().map(|node| node.pid).collect();
+        let common_pids: Vec<_> = pid_set1.intersection(&pid_set2).cloned().collect();
+        common_pids
+    }
 }

--- a/zenoh/src/net/routing/network.rs
+++ b/zenoh/src/net/routing/network.rs
@@ -160,6 +160,20 @@ impl Network {
     }
 
     #[inline]
+    pub(crate) fn get_node_from_pid(&self, pid: PeerId) -> Option<(NodeIndex, &Node)> {
+        let idx = *self.pid_to_lpsid.get(&pid)?;
+        let node = &self.graph[idx];
+        Some((idx, node))
+    }
+
+    #[inline]
+    pub(crate) fn get_node_from_pid_mut(&mut self, pid: PeerId) -> Option<(NodeIndex, &mut Node)> {
+        let idx = *self.pid_to_lpsid.get(&pid)?;
+        let node = &mut self.graph[idx];
+        Some((idx, node))
+    }
+
+    #[inline]
     pub(crate) fn get_link(&self, id: LinkId) -> Option<&Link> {
         self.links.get(id.0)
     }

--- a/zenoh/src/net/routing/network.rs
+++ b/zenoh/src/net/routing/network.rs
@@ -129,7 +129,7 @@ impl Network {
     }
 
     pub(crate) fn dot(&self) -> String {
-        std::format!(
+        format!(
             "{:?}",
             petgraph::dot::Dot::with_config(&self.graph, &[petgraph::dot::Config::EdgeNoLabel])
         )

--- a/zenoh/src/net/routing/network.rs
+++ b/zenoh/src/net/routing/network.rs
@@ -92,7 +92,6 @@ impl Link {
     }
 }
 
-#[derive(Clone)]
 pub(crate) struct Tree {
     pub(crate) parent: Option<NodeIndex>,
     pub(crate) childs: Vec<NodeIndex>,

--- a/zenoh/src/net/routing/network.rs
+++ b/zenoh/src/net/routing/network.rs
@@ -169,23 +169,23 @@ impl Network {
     }
 
     #[inline]
-    pub(crate) fn get_local_context(&self, context: Option<ZInt>, link_id: LinkId) -> usize {
+    pub(crate) fn get_local_context(&self, context: Option<ZInt>, link_id: LinkId) -> NodeIndex {
         let context = context.unwrap_or(0);
         match self.get_link(link_id) {
             Some(link) => match link.get_local_psid(&context) {
-                Some(psid) => (*psid).try_into().unwrap_or(0),
+                Some(&psid) => NodeIndex::new(psid as usize),
                 None => {
                     log::error!(
                         "Cannot find local psid for context {} on link {}",
                         context,
                         link_id
                     );
-                    0
+                    NodeIndex::new(0)
                 }
             },
             None => {
                 log::error!("Cannot find link {}", link_id);
-                0
+                NodeIndex::new(0)
             }
         }
     }

--- a/zenoh/src/net/routing/pubsub.rs
+++ b/zenoh/src/net/routing/pubsub.rs
@@ -28,7 +28,7 @@ use zenoh_protocol_core::{
 
 use crate::net::routing::router::Matches;
 
-use super::face::FaceState;
+use super::face::{FaceId, FaceState};
 use super::network::Network;
 use super::restree::Strengthen;
 use super::router::{
@@ -39,7 +39,7 @@ use super::router::{
 #[inline]
 fn send_sourced_subscription_to_net_childs(
     restree: &mut ResourceTree,
-    faces: &HashMap<usize, Arc<FaceState>>,
+    faces: &HashMap<FaceId, Arc<FaceState>>,
     net: &Network,
     childs: &[NodeIndex],
     res: &ResourceTreeIndex,
@@ -365,7 +365,7 @@ fn client_subs(tables: &Tables, res: &ResourceTreeIndex) -> Vec<Arc<FaceState>> 
 #[inline]
 fn send_forget_sourced_subscription_to_net_childs(
     restree: &mut ResourceTree,
-    faces: &HashMap<usize, Arc<FaceState>>,
+    faces: &HashMap<FaceId, Arc<FaceState>>,
     net: &Network,
     childs: &[NodeIndex],
     res: &ResourceTreeIndex,

--- a/zenoh/src/net/routing/pubsub.rs
+++ b/zenoh/src/net/routing/pubsub.rs
@@ -1138,59 +1138,60 @@ fn get_matching_pulls(
         .unwrap_or_else(|| compute_matching_pulls(tables, prefix, suffix))
 }
 
-macro_rules! send_to_first {
-    ($route:expr, $srcface:expr, $payload:expr, $channel:expr, $cong_ctrl:expr, $data_info:expr) => {
-        let (outface, key_expr, context) = $route.values().next().unwrap();
-        if $srcface.id != outface.id {
-            outface
-                .primitives
-                .send_data(
-                    &key_expr,
-                    $payload,
-                    $channel, // @TODO: Need to check the active subscriptions to determine the right reliability value
-                    $cong_ctrl,
-                    $data_info,
-                    *context,
-                )
+fn send_to_first(
+    route: &Route,
+    srcface: &FaceState,
+    payload: ZBuf,
+    channel: Channel,
+    cong_ctrl: CongestionControl,
+    data_info: Option<DataInfo>,
+) {
+    let (outface, key_expr, context) = route.values().next().unwrap();
+    if srcface.id != outface.id {
+        outface.primitives.send_data(
+            &key_expr, payload,
+            channel, // @TODO: Need to check the active subscriptions to determine the right reliability value
+            cong_ctrl, data_info, *context,
+        )
+    }
+}
+
+fn send_to_all(
+    route: &Route,
+    srcface: &FaceState,
+    payload: ZBuf,
+    channel: Channel,
+    cong_ctrl: CongestionControl,
+    data_info: Option<DataInfo>,
+) {
+    for (outface, key_expr, context) in route.values() {
+        if srcface.id != outface.id {
+            outface.primitives.send_data(
+                key_expr,
+                payload.clone(),
+                channel, // @TODO: Need to check the active subscriptions to determine the right reliability value
+                cong_ctrl,
+                data_info.clone(),
+                *context,
+            )
         }
     }
 }
 
-macro_rules! send_to_all {
-    ($route:expr, $srcface:expr, $payload:expr, $channel:expr, $cong_ctrl:expr, $data_info:expr) => {
-        for (outface, key_expr, context) in $route.values() {
-            if $srcface.id != outface.id {
-                outface
-                    .primitives
-                    .send_data(
-                        &key_expr,
-                        $payload.clone(),
-                        $channel, // @TODO: Need to check the active subscriptions to determine the right reliability value
-                        $cong_ctrl,
-                        $data_info.clone(),
-                        *context,
-                    )
-            }
-        }
+fn cache_data(
+    tables: &Tables,
+    matching_pulls: Arc<PullCaches>,
+    prefix: ResourceTreeIndex,
+    suffix: &str,
+    payload: &ZBuf,
+    info: Option<&DataInfo>,
+) {
+    for context in matching_pulls.iter() {
+        get_mut_unchecked(context).last_values.insert(
+            [&tables.restree.expr(&prefix), suffix].concat(),
+            (info.cloned(), payload.clone()),
+        );
     }
-}
-
-macro_rules! cache_data {
-    (
-        $tables:expr,
-        $matching_pulls:expr,
-        $prefix:expr,
-        $suffix:expr,
-        $payload:expr,
-        $info:expr
-    ) => {
-        for context in $matching_pulls.iter() {
-            get_mut_unchecked(context).last_values.insert(
-                [&$tables.restree.expr(&$prefix), $suffix].concat(),
-                ($info.clone(), $payload.clone()),
-            );
-        }
-    };
 }
 
 #[inline]
@@ -1228,21 +1229,35 @@ pub fn route_data(
                 let data_info = treat_timestamp!(&tables.hlc, info);
 
                 if route.len() == 1 && matching_pulls.len() == 0 {
-                    send_to_first!(route, face, payload, channel, congestion_control, data_info);
+                    send_to_first(
+                        &*route,
+                        face,
+                        payload,
+                        channel,
+                        congestion_control,
+                        data_info,
+                    );
                 } else {
                     if !matching_pulls.is_empty() {
                         let lock = zlock!(tables.pull_caches_lock);
-                        cache_data!(
-                            tables,
+                        cache_data(
+                            &*tables,
                             matching_pulls,
                             prefix,
                             expr.suffix.as_ref(),
-                            payload,
-                            data_info
+                            &payload,
+                            data_info.as_ref(),
                         );
                         drop(lock);
                     }
-                    send_to_all!(route, face, payload, channel, congestion_control, data_info);
+                    send_to_all(
+                        &*route,
+                        face,
+                        payload,
+                        channel,
+                        congestion_control,
+                        data_info,
+                    );
                 }
             }
         }
@@ -1289,22 +1304,36 @@ pub fn full_reentrant_route_data(
 
                 if route.len() == 1 && matching_pulls.len() == 0 {
                     drop(tables);
-                    send_to_first!(route, face, payload, channel, congestion_control, data_info);
+                    send_to_first(
+                        &*route,
+                        face,
+                        payload,
+                        channel,
+                        congestion_control,
+                        data_info,
+                    );
                 } else {
                     if !matching_pulls.is_empty() {
                         let lock = zlock!(tables.pull_caches_lock);
-                        cache_data!(
-                            tables,
+                        cache_data(
+                            &*tables,
                             matching_pulls,
                             prefix,
                             expr.suffix.as_ref(),
-                            payload,
-                            data_info
+                            &payload,
+                            data_info.as_ref(),
                         );
                         drop(lock);
                     }
                     drop(tables);
-                    send_to_all!(route, face, payload, channel, congestion_control, data_info);
+                    send_to_all(
+                        &*route,
+                        face,
+                        payload,
+                        channel,
+                        congestion_control,
+                        data_info,
+                    );
                 }
             }
         }

--- a/zenoh/src/net/routing/queries.rs
+++ b/zenoh/src/net/routing/queries.rs
@@ -30,7 +30,7 @@ use zenoh_protocol_core::{
     Target, WhatAmI, ZInt,
 };
 
-use super::face::FaceState;
+use super::face::{FaceId, FaceState};
 use super::network::Network;
 use super::restree::Strengthen;
 use super::router::Tables;
@@ -210,7 +210,7 @@ fn local_qabl_info(
 #[inline]
 fn send_sourced_queryable_to_net_childs<Face: std::borrow::Borrow<Arc<FaceState>>>(
     restree: &mut ResourceTree,
-    faces: &HashMap<usize, Arc<FaceState>>,
+    faces: &HashMap<FaceId, Arc<FaceState>>,
     net: &Network,
     childs: &[NodeIndex],
     res: &ResourceTreeIndex,
@@ -570,7 +570,7 @@ fn client_qabls(tables: &Tables, res: &ResourceTreeIndex, kind: ZInt) -> Vec<Arc
 #[inline]
 fn send_forget_sourced_queryable_to_net_childs(
     restree: &mut ResourceTree,
-    faces: &HashMap<usize, Arc<FaceState>>,
+    faces: &HashMap<FaceId, Arc<FaceState>>,
     net: &Network,
     childs: &[NodeIndex],
     res: &ResourceTreeIndex,

--- a/zenoh/src/net/routing/queries.rs
+++ b/zenoh/src/net/routing/queries.rs
@@ -1378,7 +1378,6 @@ fn compute_final_route(
     }
 }
 
-#[derive(Clone)]
 struct QueryCleanup {
     tables: Arc<RwLock<Tables>>,
     face: Weak<FaceState>,

--- a/zenoh/src/net/routing/restree/arctree.rs
+++ b/zenoh/src/net/routing/restree/arctree.rs
@@ -1,3 +1,8 @@
+use std::{
+    borrow::Cow,
+    hash::{Hash, Hasher},
+};
+
 //
 // Copyright (c) 2017, 2020 ADLINK Technology Inc.
 //
@@ -34,7 +39,7 @@ impl<Weight> Node<Weight> {
         }
     }
 
-    fn expr(&self) -> std::borrow::Cow<'static, str> {
+    fn expr(&self) -> Cow<'static, str> {
         match &self.parent {
             Some(parent) => [&parent.expr() as &str, &self.suffix].concat().into(),
             None => "".into(),
@@ -49,8 +54,8 @@ impl<Weight> PartialEq for Node<Weight> {
 }
 impl<Weight> Eq for Node<Weight> {}
 
-impl<Weight> std::hash::Hash for Node<Weight> {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl<Weight> Hash for Node<Weight> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.expr().hash(state);
     }
 }
@@ -355,7 +360,7 @@ impl<'a, Weight: 'a> ResourceTreeContainer<'a, Weight> for ArcTree<Weight> {
     }
 
     #[inline]
-    fn expr<'b>(&'b self, index: &'b Self::Index) -> std::borrow::Cow<'b, str> {
+    fn expr<'b>(&'b self, index: &'b Self::Index) -> Cow<'b, str> {
         index.expr()
     }
 

--- a/zenoh/src/net/routing/restree/mod.rs
+++ b/zenoh/src/net/routing/restree/mod.rs
@@ -12,6 +12,8 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 
+use std::borrow::Cow;
+
 use petgraph::visit::Walker;
 
 pub mod arctree;
@@ -55,7 +57,7 @@ pub trait ResourceTreeContainer<'a, Weight>: 'a {
         from: &Self::Index,
     ) -> Self::Matches;
 
-    fn expr<'b>(&'b self, index: &'b Self::Index) -> std::borrow::Cow<'b, str>;
+    fn expr<'b>(&'b self, index: &'b Self::Index) -> Cow<'b, str>;
     fn weight<'b>(&'b self, index: &'b Self::Index) -> &'b Weight;
     fn weight_mut<'b>(&'b mut self, index: &'b Self::Index) -> &'b mut Weight;
 }
@@ -186,7 +188,7 @@ impl<T: for<'a> ResourceTreeContainer<'a, Weight, Index = Index>, Index: Clone, 
     }
 
     #[inline]
-    pub fn expr<'b>(&'b self, index: &'b Index) -> std::borrow::Cow<'b, str> {
+    pub fn expr<'b>(&'b self, index: &'b Index) -> Cow<'b, str> {
         self.container.expr(index)
     }
 

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -12,7 +12,7 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 use super::face::{Face, FaceId, FaceState};
-use super::network::{shared_nodes, Network};
+use super::network::{shared_nodes, LinkId, Network};
 pub use super::pubsub::*;
 pub use super::queries::*;
 use super::restree::ResourceTreeContainer;
@@ -231,7 +231,7 @@ impl Tables {
         pid: PeerId,
         whatami: WhatAmI,
         primitives: Arc<dyn Primitives + Send + Sync>,
-        link_id: usize,
+        link_id: LinkId,
     ) -> Weak<FaceState> {
         let fid = FaceId::new(self.face_counter);
         self.face_counter += 1;
@@ -254,7 +254,7 @@ impl Tables {
         whatami: WhatAmI,
         primitives: Arc<dyn Primitives + Send + Sync>,
     ) -> Weak<FaceState> {
-        self.open_net_face(pid, whatami, primitives, 0)
+        self.open_net_face(pid, whatami, primitives, LinkId::new(0))
     }
 
     pub fn close_face(&mut self, face: &Weak<FaceState>) {
@@ -659,7 +659,7 @@ impl Router {
                 .as_mut()
                 .unwrap()
                 .add_link(transport.clone()),
-            _ => 0,
+            _ => LinkId::new(0),
         };
 
         if tables.whatami == WhatAmI::Router {

--- a/zenoh/src/net/routing/router.rs
+++ b/zenoh/src/net/routing/router.rs
@@ -12,7 +12,7 @@
 //   ADLINK zenoh team, <zenoh@adlink-labs.tech>
 //
 use super::face::{Face, FaceId, FaceState};
-use super::network::{shared_nodes, LinkId, Network};
+use super::network::{LinkId, Network};
 pub use super::pubsub::*;
 pub use super::queries::*;
 use super::restree::ResourceTreeContainer;
@@ -618,10 +618,11 @@ impl Router {
                 peers_autoconnect,
                 routers_autoconnect_gossip,
             ));
-            tables.shared_nodes = shared_nodes(
-                tables.routers_net.as_ref().unwrap(),
-                tables.peers_net.as_ref().unwrap(),
-            );
+            tables.shared_nodes = tables
+                .routers_net
+                .as_ref()
+                .unwrap()
+                .shared_nodes(tables.peers_net.as_ref().unwrap());
         }
     }
 
@@ -663,10 +664,11 @@ impl Router {
         };
 
         if tables.whatami == WhatAmI::Router {
-            tables.shared_nodes = shared_nodes(
-                tables.routers_net.as_ref().unwrap(),
-                tables.peers_net.as_ref().unwrap(),
-            );
+            tables.shared_nodes = tables
+                .routers_net
+                .as_ref()
+                .unwrap()
+                .shared_nodes(tables.peers_net.as_ref().unwrap());
         }
 
         let handler = {
@@ -749,10 +751,11 @@ impl TransportPeerEventHandler for LinkStateInterceptor {
                                 );
                             }
 
-                            tables.shared_nodes = shared_nodes(
-                                tables.routers_net.as_ref().unwrap(),
-                                tables.peers_net.as_ref().unwrap(),
-                            );
+                            tables.shared_nodes = tables
+                                .routers_net
+                                .as_ref()
+                                .unwrap()
+                                .shared_nodes(tables.peers_net.as_ref().unwrap());
 
                             tables.schedule_compute_trees(self.tables.clone(), WhatAmI::Router);
                         }
@@ -770,10 +773,11 @@ impl TransportPeerEventHandler for LinkStateInterceptor {
                             }
 
                             if tables.whatami == WhatAmI::Router {
-                                tables.shared_nodes = shared_nodes(
-                                    tables.routers_net.as_ref().unwrap(),
-                                    tables.peers_net.as_ref().unwrap(),
-                                );
+                                tables.shared_nodes = tables
+                                    .routers_net
+                                    .as_ref()
+                                    .unwrap()
+                                    .shared_nodes(tables.peers_net.as_ref().unwrap());
                             }
 
                             tables.schedule_compute_trees(self.tables.clone(), WhatAmI::Peer);
@@ -807,10 +811,11 @@ impl TransportPeerEventHandler for LinkStateInterceptor {
                             queries_remove_node(&mut tables, &removed_node.pid, WhatAmI::Router);
                         }
 
-                        tables.shared_nodes = shared_nodes(
-                            tables.routers_net.as_ref().unwrap(),
-                            tables.peers_net.as_ref().unwrap(),
-                        );
+                        tables.shared_nodes = tables
+                            .routers_net
+                            .as_ref()
+                            .unwrap()
+                            .shared_nodes(tables.peers_net.as_ref().unwrap());
 
                         tables.schedule_compute_trees(tables_ref.clone(), WhatAmI::Router);
                     }
@@ -825,10 +830,11 @@ impl TransportPeerEventHandler for LinkStateInterceptor {
                         }
 
                         if tables.whatami == WhatAmI::Router {
-                            tables.shared_nodes = shared_nodes(
-                                tables.routers_net.as_ref().unwrap(),
-                                tables.peers_net.as_ref().unwrap(),
-                            );
+                            tables.shared_nodes = tables
+                                .routers_net
+                                .as_ref()
+                                .unwrap()
+                                .shared_nodes(tables.peers_net.as_ref().unwrap());
                         }
 
                         tables.schedule_compute_trees(tables_ref.clone(), WhatAmI::Peer);


### PR DESCRIPTION
This PR pushes a series of internal code refactoring based on Oliver's routing-refactor branch.

- Replace full qualified paths with "use"s. For example, `std::borrow::Cow` is rewritten as `Cow` for readability.
- Some macros are changed to functions. For example, `send_to_first and `send_to_many`. It reduces the macro processing a bit.
- Use `NodeId`, `FaceId` and `NodeIndex` instead of `usize` for index numbers. It improves readability and avoids accidental misusage. 
- The Clone impls are removed from the types that are not intended to be cloned, such as `Face`. They are wrapped to `Arc` instead.
- Some function generics are removed from internal code, such as `Face: Borrow<Arc<FaceState>>`.
- The type of the field `Node::links` is changed from `Vec` to `HashSet` to speed up `.contains()` search.

More incremental changes will be pushed later. Before it happens, we'd make sure these changes are correctly done.