### PR TITLE
Follow the guideline of integration tests from the Rust book

### DIFF
--- a/commons/zenoh-shm/src/lib.rs
+++ b/commons/zenoh-shm/src/lib.rs
@@ -39,22 +39,12 @@ macro_rules! tested_crate_module {
     };
 }
 
-#[macro_export]
-macro_rules! test_helpers_module {
-    () => {
-        #[cfg(feature = "test")]
-        pub mod test_helpers;
-    };
-}
-
 pub mod api;
 pub mod header;
 pub mod posix_shm;
 pub mod reader;
 pub mod watchdog;
 pub mod zsliceshm_access;
-
-test_helpers_module!();
 
 /// Informations about a [`SharedMemoryBuf`].
 ///

--- a/commons/zenoh-shm/tests/common/mod.rs
+++ b/commons/zenoh-shm/tests/common/mod.rs
@@ -12,7 +12,10 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-use std::{sync::{Arc, atomic::AtomicBool}, thread::JoinHandle};
+use std::{
+    sync::{atomic::AtomicBool, Arc},
+    thread::JoinHandle,
+};
 
 use zenoh_result::ZResult;
 
@@ -66,7 +69,7 @@ pub fn load_fn(
 
 pub struct CpuLoad {
     handle: Option<JoinHandle<()>>,
-    flag: Arc<AtomicBool>
+    flag: Arc<AtomicBool>,
 }
 
 impl Drop for CpuLoad {
@@ -89,16 +92,14 @@ impl CpuLoad {
         Self::new(1)
     }
 
-    fn  new(thread_count: usize) -> Self {
+    fn new(thread_count: usize) -> Self {
         let flag = Arc::new(AtomicBool::new(true));
-        
+
         let c_flag = flag.clone();
         let handle = Some(std::thread::spawn(move || {
             execute_concurrent(thread_count, 1, load_fn(c_flag));
         }));
-    
-        Self{handle, flag}
-        
+
+        Self { handle, flag }
     }
 }
-

--- a/commons/zenoh-shm/tests/header.rs
+++ b/commons/zenoh-shm/tests/header.rs
@@ -16,13 +16,13 @@ use std::sync::atomic::Ordering::Relaxed;
 
 use rand::Rng;
 use zenoh_result::ZResult;
-use zenoh_shm::{
-    header::{
-        descriptor::HeaderDescriptor, storage::GLOBAL_HEADER_STORAGE,
-        subscription::GLOBAL_HEADER_SUBSCRIPTION,
-    },
-    test_helpers::execute_concurrent,
+use zenoh_shm::header::{
+    descriptor::HeaderDescriptor, storage::GLOBAL_HEADER_STORAGE,
+    subscription::GLOBAL_HEADER_SUBSCRIPTION,
 };
+
+pub mod common;
+use common::execute_concurrent;
 
 fn header_alloc_fn() -> impl Fn(usize, usize) -> ZResult<()> + Clone + Send + Sync + 'static {
     |_task_index: usize, _iteration: usize| -> ZResult<()> {

--- a/commons/zenoh-shm/tests/periodic_task.rs
+++ b/commons/zenoh-shm/tests/periodic_task.rs
@@ -17,7 +17,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use zenoh_shm::{test_helpers::CpuLoad, watchdog::periodic_task::PeriodicTask};
+use zenoh_shm::watchdog::periodic_task::PeriodicTask;
+
+pub mod common;
+use common::CpuLoad;
 
 const TASK_PERIOD: Duration = Duration::from_millis(50);
 const TASK_DELTA: Duration = Duration::from_millis(5);

--- a/commons/zenoh-shm/tests/posix_array.rs
+++ b/commons/zenoh-shm/tests/posix_array.rs
@@ -15,7 +15,10 @@
 use std::{fmt::Debug, mem::size_of};
 
 use num_traits::{AsPrimitive, PrimInt, Unsigned};
-use zenoh_shm::{posix_shm::array::ArrayInSHM, test_helpers::TEST_SEGMENT_PREFIX};
+use zenoh_shm::posix_shm::array::ArrayInSHM;
+
+pub mod common;
+use common::TEST_SEGMENT_PREFIX;
 
 type TestSegmentID = u32;
 

--- a/commons/zenoh-shm/tests/posix_segment.rs
+++ b/commons/zenoh-shm/tests/posix_segment.rs
@@ -14,10 +14,10 @@
 
 use std::{fmt::Display, slice};
 
-use zenoh_shm::{
-    posix_shm::segment::Segment,
-    test_helpers::{validate_memory, TEST_SEGMENT_PREFIX},
-};
+use zenoh_shm::posix_shm::segment::Segment;
+
+pub mod common;
+use common::{validate_memory, TEST_SEGMENT_PREFIX};
 
 fn validate_segment<ID>(segment1: &Segment<ID>, segment2: &Segment<ID>)
 where

--- a/commons/zenoh-shm/tests/watchdog.rs
+++ b/commons/zenoh-shm/tests/watchdog.rs
@@ -18,12 +18,12 @@ use std::{
 };
 
 use zenoh_result::{bail, ZResult};
-use zenoh_shm::{
-    test_helpers::{execute_concurrent, CpuLoad},
-    watchdog::{
-        confirmator::GLOBAL_CONFIRMATOR, storage::GLOBAL_STORAGE, validator::GLOBAL_VALIDATOR,
-    },
+use zenoh_shm::watchdog::{
+    confirmator::GLOBAL_CONFIRMATOR, storage::GLOBAL_STORAGE, validator::GLOBAL_VALIDATOR,
 };
+
+pub mod common;
+use common::{execute_concurrent, CpuLoad};
 
 const VALIDATION_PERIOD: Duration = Duration::from_millis(100);
 const CONFIRMATION_PERIOD: Duration = Duration::from_millis(50);


### PR DESCRIPTION
As suggested in the Rust book, it's better to manage the integration test with its helper functions like [this](https://doc.rust-lang.org/book/ch11-03-test-organization.html#submodules-in-integration-tests). Note that we need to import the module with `pub` due to this unsolved [issue](https://github.com/rust-lang/rust/issues/46379).