### PR TITLE
Simplify the implementation with a plain HashMap

### DIFF
--- a/commons/zenoh-shm/src/api/client_storage/mod.rs
+++ b/commons/zenoh-shm/src/api/client_storage/mod.rs
@@ -135,12 +135,12 @@ impl SharedMemoryClientStorage {
     /// Get the list of supported SHM protocols.
     #[zenoh_macros::unstable_doc]
     pub fn supported_protocols(&self) -> Vec<ProtocolID> {
-        self.clients.get_clients().keys().copied().collect()
+        self.clients.keys().copied().collect()
     }
 
     fn new(clients: HashMap<ProtocolID, Box<dyn SharedMemoryClient>>) -> Self {
         Self {
-            clients: ClientStorage::new(clients),
+            clients: ClientStorage::from(clients),
             segments: RwLock::default(),
         }
     }

--- a/commons/zenoh-shm/src/reader.rs
+++ b/commons/zenoh-shm/src/reader.rs
@@ -85,7 +85,6 @@ impl SharedMemoryReader {
         // find appropriate client
         let client = self
             .clients
-            .get_clients()
             .get(&id.protocol)
             .ok_or_else(|| zerror!("Unsupported SHM protocol: {}", id.protocol))?;
 
@@ -106,33 +105,7 @@ impl SharedMemoryReader {
     }
 }
 
-#[derive(Debug)]
-pub(crate) struct ClientStorage<Inner>
-where
-    Inner: Sized,
-{
-    clients: HashMap<ProtocolID, Inner>,
-}
-
-impl<Inner: Sized> ClientStorage<Inner> {
-    pub(crate) fn new(clients: HashMap<ProtocolID, Inner>) -> Self {
-        Self { clients }
-    }
-
-    pub(crate) fn get_clients(&self) -> &HashMap<ProtocolID, Inner> {
-        &self.clients
-    }
-}
-
-/// # Safety
-/// Only immutable access to internal container is allowed,
-/// so we are Send if the contained type is Send
-unsafe impl<Inner: Send> Send for ClientStorage<Inner> {}
-
-/// # Safety
-/// Only immutable access to internal container is allowed,
-/// so we are Sync if the contained type is Sync
-unsafe impl<Inner: Sync> Sync for ClientStorage<Inner> {}
+pub(crate) type ClientStorage<T> = HashMap<ProtocolID, T>;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub(crate) struct GlobalDataSegmentID {


### PR DESCRIPTION
If what we want to have is simply a HashMap, then doing a type alias is more efficient. In addition, we don't need to impose unsafe traits.