### PR TITLE
feat(cuda): CUDA IPC transport via ZSliceKind::CudaPtr and zenoh-cuda crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,9 +2258,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5948,6 +5948,7 @@ dependencies = [
  "zenoh-collections",
  "zenoh-config",
  "zenoh-core",
+ "zenoh-cuda",
  "zenoh-keyexpr",
  "zenoh-link",
  "zenoh-link-commons",
@@ -5995,6 +5996,7 @@ dependencies = [
  "tracing",
  "uhlc",
  "zenoh-buffers",
+ "zenoh-cuda",
  "zenoh-protocol",
  "zenoh-shm",
  "zenoh-util",
@@ -6050,6 +6052,15 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sha3",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-cuda"
+version = "1.7.2"
+dependencies = [
+ "tracing",
+ "zenoh-buffers",
  "zenoh-result",
 ]
 
@@ -6591,6 +6602,7 @@ dependencies = [
  "zenoh-config",
  "zenoh-core",
  "zenoh-crypto",
+ "zenoh-cuda",
  "zenoh-link",
  "zenoh-link-commons",
  "zenoh-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "commons/zenoh-buffers",
   "commons/zenoh-codec",
   "commons/zenoh-collections",
+  "commons/zenoh-cuda",
   "commons/zenoh-config",
   "commons/zenoh-core",
   "commons/zenoh-crypto",
@@ -234,6 +235,7 @@ zenoh-link-ws = { version = "=1.7.2", path = "io/zenoh-links/zenoh-link-ws" }
 zenoh-macros = { version = "=1.7.2", path = "commons/zenoh-macros" }
 zenoh-plugin-trait = { version = "=1.7.2", path = "plugins/zenoh-plugin-trait", default-features = false }
 zenoh-protocol = { version = "=1.7.2", path = "commons/zenoh-protocol", default-features = false }
+zenoh-cuda = { version = "=1.7.2", path = "commons/zenoh-cuda" }
 zenoh-result = { version = "=1.7.2", path = "commons/zenoh-result", default-features = false }
 zenoh-runtime = { version = "=1.7.2", path = "commons/zenoh-runtime" }
 zenoh-shm = { version = "=1.7.2", path = "commons/zenoh-shm" }

--- a/commons/zenoh-buffers/src/zbuf.rs
+++ b/commons/zenoh-buffers/src/zbuf.rs
@@ -60,6 +60,13 @@ impl ZBuf {
 
     #[inline(always)]
     pub fn push_zslice(&mut self, zslice: ZSlice) {
+        // CudaPtr ZSlices have zero CPU-visible bytes (device memory) but must be
+        // stored so the transport codec can extract the IPC handle for wire encoding.
+        #[cfg(feature = "cuda")]
+        if zslice.kind == crate::ZSliceKind::CudaPtr {
+            self.slices.push(zslice);
+            return;
+        }
         if !zslice.is_empty() {
             self.slices.push(zslice);
         }

--- a/commons/zenoh-buffers/src/zslice.rs
+++ b/commons/zenoh-buffers/src/zslice.rs
@@ -86,6 +86,10 @@ impl<const N: usize> ZSliceBuffer for [u8; N] {
 pub enum ZSliceKind {
     Raw = 0,
     ShmPtr = 1,
+    /// CUDA IPC handle — as_slice() is valid only for pinned/unified memory.
+    /// Device-only memory has len=0 in the ZSlice; use downcast_ref::<CudaBufInner>().cuda_len().
+    #[cfg(feature = "cuda")]
+    CudaPtr = 2,
 }
 
 /// A cloneable wrapper to a contiguous slice of bytes.

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -30,7 +30,7 @@ version = { workspace = true }
 
 [features]
 default = ["std"]
-cuda = ["zenoh-buffers/cuda", "zenoh-cuda"]
+cuda = ["zenoh-buffers/cuda", "zenoh-cuda", "zenoh-protocol/cuda"]
 shared-memory = [
   "std",
   "zenoh-buffers/shared-memory",

--- a/commons/zenoh-codec/Cargo.toml
+++ b/commons/zenoh-codec/Cargo.toml
@@ -30,6 +30,7 @@ version = { workspace = true }
 
 [features]
 default = ["std"]
+cuda = ["zenoh-buffers/cuda", "zenoh-cuda"]
 shared-memory = [
   "std",
   "zenoh-buffers/shared-memory",
@@ -42,6 +43,7 @@ std = ["tracing", "uhlc/std", "zenoh-buffers/std", "zenoh-protocol/std"]
 tracing = { workspace = true, optional = true }
 uhlc = { workspace = true }
 zenoh-buffers = { workspace = true, default-features = false }
+zenoh-cuda = { workspace = true, optional = true }
 zenoh-protocol = { workspace = true }
 zenoh-shm = { workspace = true, optional = true }
 

--- a/commons/zenoh-codec/src/core/zbuf.rs
+++ b/commons/zenoh-codec/src/core/zbuf.rs
@@ -223,7 +223,10 @@ mod shm {
                                         len as usize,
                                         device_id as i32,
                                     )
-                                    .map_err(|_| DidntRead)?;
+                                    .map_err(|e| {
+                                        tracing::error!("CUDA IPC open failed (len={len}, device_id={device_id}): {e}");
+                                        DidntRead
+                                    })?;
                                     let mut zslice = ZSlice::from(Arc::new(cuda_buf));
                                     zslice.kind = ZSliceKind::CudaPtr;
                                     zbuf.push_zslice(zslice);

--- a/commons/zenoh-codec/src/core/zbuf.rs
+++ b/commons/zenoh-codec/src/core/zbuf.rs
@@ -109,13 +109,25 @@ mod shm {
 
     const RAW: u8 = 0;
     const SHM_PTR: u8 = 1;
+    #[cfg(feature = "cuda")]
+    const CUDA_PTR: u8 = 2;
+
+    // Wire size for a CUDA IPC entry: kind(1) + handle(64) + len as u64(8) + device_id as i32(4)
+    #[cfg(feature = "cuda")]
+    const CUDA_WIRE_SIZE: usize = 1 + 64 + 8 + 4;
 
     macro_rules! zbuf_sliced_impl {
         ($bound:ty) => {
             impl LCodec<&ZBuf> for Zenoh080Sliced<$bound> {
                 fn w_len(self, message: &ZBuf) -> usize {
                     if self.is_sliced {
-                        message.zslices().fold(0, |acc, x| acc + 1 + x.len())
+                        message.zslices().fold(0, |acc, x| {
+                            #[cfg(feature = "cuda")]
+                            if x.kind == ZSliceKind::CudaPtr {
+                                return acc + CUDA_WIRE_SIZE;
+                            }
+                            acc + 1 + x.len()
+                        })
                     } else {
                         self.codec.w_len(message)
                     }
@@ -149,6 +161,21 @@ mod shm {
                                     // valid until it is received.
                                     unsafe { shmb.inc_ref_count() };
                                 }
+                                #[cfg(feature = "cuda")]
+                                ZSliceKind::CudaPtr => {
+                                    use zenoh_cuda::CudaBufInner;
+                                    self.codec.write(&mut *writer, CUDA_PTR)?;
+                                    let cuda = zs
+                                        .downcast_ref::<CudaBufInner>()
+                                        .expect("CudaPtr ZSlice must contain CudaBufInner");
+                                    // Send IPC handle + length + device — no bulk data.
+                                    writer
+                                        .write_exact(&cuda.ipc_handle)
+                                        .map_err(|_| DidntWrite)?;
+                                    self.codec.write(&mut *writer, cuda.cuda_len as u64)?;
+                                    // device_id encoded as u32 (negative values not expected)
+                                    self.codec.write(&mut *writer, cuda.device_id as u32)?;
+                                }
                             }
                         }
                     } else {
@@ -180,6 +207,25 @@ mod shm {
                                 SHM_PTR => {
                                     let mut zslice: ZSlice = self.codec.read(&mut *reader)?;
                                     zslice.kind = ZSliceKind::ShmPtr;
+                                    zbuf.push_zslice(zslice);
+                                }
+                                #[cfg(feature = "cuda")]
+                                CUDA_PTR => {
+                                    use std::sync::Arc;
+                                    use zenoh_cuda::CudaBufInner;
+                                    let mut handle = [0u8; 64];
+                                    reader.read_exact(&mut handle).map_err(|_| DidntRead)?;
+                                    let len: u64 = self.codec.read(&mut *reader)?;
+                                    let device_id: u32 = self.codec.read(&mut *reader)?;
+                                    // Open IPC handle — maps the sender's device memory.
+                                    let cuda_buf = CudaBufInner::from_ipc(
+                                        handle,
+                                        len as usize,
+                                        device_id as i32,
+                                    )
+                                    .map_err(|_| DidntRead)?;
+                                    let mut zslice = ZSlice::from(Arc::new(cuda_buf));
+                                    zslice.kind = ZSliceKind::CudaPtr;
                                     zbuf.push_zslice(zslice);
                                 }
                                 _ => return Err(DidntRead),

--- a/commons/zenoh-codec/src/transport/init.rs
+++ b/commons/zenoh-codec/src/transport/init.rs
@@ -53,6 +53,8 @@ where
             ext_lowlatency,
             ext_compression,
             ext_patch,
+            #[cfg(feature = "cuda")]
+            ext_mem,
         } = x;
 
         // Header
@@ -71,6 +73,10 @@ where
         #[cfg(feature = "shared-memory")]
         {
             n_exts += ext_shm.is_some() as u8;
+        }
+        #[cfg(feature = "cuda")]
+        {
+            n_exts += ext_mem.is_some() as u8;
         }
 
         if n_exts != 0 {
@@ -130,6 +136,11 @@ where
         if *ext_patch != ext::PatchType::NONE {
             n_exts -= 1;
             self.write(&mut *writer, (*ext_patch, n_exts != 0))?;
+        }
+        #[cfg(feature = "cuda")]
+        if let Some(mem) = ext_mem.as_ref() {
+            n_exts -= 1;
+            self.write(&mut *writer, (mem, n_exts != 0))?;
         }
 
         Ok(())
@@ -193,6 +204,8 @@ where
         let mut ext_lowlatency = None;
         let mut ext_compression = None;
         let mut ext_patch = ext::PatchType::NONE;
+        #[cfg(feature = "cuda")]
+        let mut ext_mem = None;
 
         let mut has_ext = imsg::has_flag(self.header, flag::Z);
         while has_ext {
@@ -240,6 +253,12 @@ where
                     ext_patch = p;
                     has_ext = ext;
                 }
+                #[cfg(feature = "cuda")]
+                ext::Mem::ID => {
+                    let (m, ext): (ext::Mem, bool) = eodec.read(&mut *reader)?;
+                    ext_mem = Some(m);
+                    has_ext = ext;
+                }
                 _ => {
                     has_ext = extension::skip(reader, "InitSyn", ext)?;
                 }
@@ -261,6 +280,8 @@ where
             ext_lowlatency,
             ext_compression,
             ext_patch,
+            #[cfg(feature = "cuda")]
+            ext_mem,
         })
     }
 }
@@ -289,6 +310,8 @@ where
             ext_lowlatency,
             ext_compression,
             ext_patch,
+            #[cfg(feature = "cuda")]
+            ext_mem,
         } = x;
 
         // Header
@@ -307,6 +330,10 @@ where
         #[cfg(feature = "shared-memory")]
         {
             n_exts += ext_shm.is_some() as u8;
+        }
+        #[cfg(feature = "cuda")]
+        {
+            n_exts += ext_mem.is_some() as u8;
         }
 
         if n_exts != 0 {
@@ -369,6 +396,11 @@ where
         if *ext_patch != ext::PatchType::NONE {
             n_exts -= 1;
             self.write(&mut *writer, (*ext_patch, n_exts != 0))?;
+        }
+        #[cfg(feature = "cuda")]
+        if let Some(mem) = ext_mem.as_ref() {
+            n_exts -= 1;
+            self.write(&mut *writer, (mem, n_exts != 0))?;
         }
 
         Ok(())
@@ -435,6 +467,8 @@ where
         let mut ext_lowlatency = None;
         let mut ext_compression = None;
         let mut ext_patch = ext::PatchType::NONE;
+        #[cfg(feature = "cuda")]
+        let mut ext_mem = None;
 
         let mut has_ext = imsg::has_flag(self.header, flag::Z);
         while has_ext {
@@ -482,6 +516,12 @@ where
                     ext_patch = p;
                     has_ext = ext;
                 }
+                #[cfg(feature = "cuda")]
+                ext::Mem::ID => {
+                    let (m, ext): (ext::Mem, bool) = eodec.read(&mut *reader)?;
+                    ext_mem = Some(m);
+                    has_ext = ext;
+                }
                 _ => {
                     has_ext = extension::skip(reader, "InitAck", ext)?;
                 }
@@ -504,6 +544,8 @@ where
             ext_lowlatency,
             ext_compression,
             ext_patch,
+            #[cfg(feature = "cuda")]
+            ext_mem,
         })
     }
 }

--- a/commons/zenoh-cuda/Cargo.toml
+++ b/commons/zenoh-cuda/Cargo.toml
@@ -14,23 +14,20 @@
 [package]
 authors = { workspace = true }
 categories = { workspace = true }
-description = "Internal crate for zenoh."
+description = "CUDA device memory support for zenoh ZSlice transport."
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-name = "zenoh-buffers"
+name = "zenoh-cuda"
 repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["std"]
-cuda = []
-shared-memory = []
 std = []
-test = ["rand"]
 
 [dependencies]
-rand = { workspace = true, optional = true }
-zenoh-collections = { workspace = true, default-features = false }
+tracing = { workspace = true }
+zenoh-buffers = { workspace = true, features = ["shared-memory", "cuda"] }
+zenoh-result = { workspace = true }

--- a/commons/zenoh-cuda/build.rs
+++ b/commons/zenoh-cuda/build.rs
@@ -11,6 +11,9 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 fn main() {
+    // Re-run if CUDA_PATH changes so the linker search path stays in sync.
+    println!("cargo:rerun-if-env-changed=CUDA_PATH");
+
     // Link against CUDA runtime library
     println!("cargo:rustc-link-lib=dylib=cudart");
 

--- a/commons/zenoh-cuda/build.rs
+++ b/commons/zenoh-cuda/build.rs
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+fn main() {
+    // Link against CUDA runtime library
+    println!("cargo:rustc-link-lib=dylib=cudart");
+
+    // Common CUDA installation paths
+    if let Ok(cuda_path) = std::env::var("CUDA_PATH") {
+        println!("cargo:rustc-link-search={cuda_path}/lib64");
+        println!("cargo:rustc-link-search={cuda_path}/lib");
+    } else {
+        println!("cargo:rustc-link-search=/usr/local/cuda/lib64");
+        println!("cargo:rustc-link-search=/usr/local/cuda/lib");
+        println!("cargo:rustc-link-search=/usr/lib/x86_64-linux-gnu");
+    }
+}

--- a/commons/zenoh-cuda/src/lib.rs
+++ b/commons/zenoh-cuda/src/lib.rs
@@ -51,6 +51,7 @@ extern "C" {
     fn cudaSetDevice(device: i32) -> i32;
     fn cudaMallocHost(ptr: *mut *mut u8, size: usize) -> i32;
     fn cudaFreeHost(ptr: *mut u8) -> i32;
+    fn cudaMalloc(ptr: *mut *mut u8, size: usize) -> i32;
     fn cudaMallocManaged(ptr: *mut *mut u8, size: usize, flags: u32) -> i32;
     fn cudaFree(ptr: *mut u8) -> i32;
     fn cudaIpcGetMemHandle(handle: *mut u8, dev_ptr: *mut u8) -> i32;
@@ -93,21 +94,20 @@ unsafe impl Send for CudaBufInner {}
 unsafe impl Sync for CudaBufInner {}
 
 impl CudaBufInner {
-    /// Allocate pinned host memory and register for CUDA IPC.
+    /// Allocate pinned host memory (CPU-writable, GPU DMA-accessible).
     ///
-    /// Pinned memory is CPU-writable and GPU DMA-accessible. Suitable for
-    /// tensors that need occasional CPU writes (e.g. pre-processing on host).
+    /// Pinned memory is accessible from both CPU and GPU. It is serialized as
+    /// raw bytes (not via IPC handle) since it has a valid CPU address.
     pub fn alloc_pinned(len: usize, device_id: i32) -> ZResult<Self> {
         let mut ptr: *mut u8 = std::ptr::null_mut();
         unsafe {
             check_cuda(cudaSetDevice(device_id), "cudaSetDevice")?;
             check_cuda(cudaMallocHost(&mut ptr, len), "cudaMallocHost")?;
         }
-        let ipc_handle = Self::get_ipc_handle(ptr, "alloc_pinned")?;
         Ok(Self {
             ptr,
             cuda_len: len,
-            ipc_handle,
+            ipc_handle: [0u8; 64], // not used — pinned memory has no IPC handle
             device_id,
             mem_kind: CudaMemKind::Pinned,
             is_ipc_mapping: false,
@@ -116,9 +116,8 @@ impl CudaBufInner {
 
     /// Allocate unified memory (`cudaMallocManaged`).
     ///
-    /// Unified memory is CPU- and GPU-accessible. Best for tensors that are
-    /// written on CPU and consumed on GPU (or vice versa), at the cost of
-    /// page-migration overhead on first access.
+    /// Unified memory is CPU- and GPU-accessible. Serialized as raw bytes
+    /// (not via IPC handle) since it has a valid CPU address.
     pub fn alloc_unified(len: usize, device_id: i32) -> ZResult<Self> {
         let mut ptr: *mut u8 = std::ptr::null_mut();
         unsafe {
@@ -128,21 +127,41 @@ impl CudaBufInner {
                 "cudaMallocManaged",
             )?;
         }
-        let ipc_handle = Self::get_ipc_handle(ptr, "alloc_unified")?;
         Ok(Self {
             ptr,
             cuda_len: len,
-            ipc_handle,
+            ipc_handle: [0u8; 64], // not used — unified memory has no IPC handle
             device_id,
             mem_kind: CudaMemKind::Unified,
             is_ipc_mapping: false,
         })
     }
 
-    /// Wrap an existing device-only allocation (`cudaMalloc`).
+    /// Allocate device-only memory (`cudaMalloc`) and capture its IPC handle.
     ///
-    /// `as_slice()` returns `&[]` for this kind — the buffer can only be
-    /// accessed by GPU kernels. The IPC handle encodes the allocation pointer.
+    /// `as_slice()` returns `&[]` — the buffer is GPU-only. The IPC handle is
+    /// sent over the wire so the subscriber can open the allocation directly.
+    pub fn alloc_device(len: usize, device_id: i32) -> ZResult<Self> {
+        let mut ptr: *mut u8 = std::ptr::null_mut();
+        unsafe {
+            check_cuda(cudaSetDevice(device_id), "cudaSetDevice")?;
+            check_cuda(cudaMalloc(&mut ptr, len), "cudaMalloc")?;
+        }
+        let ipc_handle = Self::get_ipc_handle(ptr, "alloc_device")?;
+        Ok(Self {
+            ptr,
+            cuda_len: len,
+            ipc_handle,
+            device_id,
+            mem_kind: CudaMemKind::Device,
+            is_ipc_mapping: false,
+        })
+    }
+
+    /// Wrap an existing device-only allocation (`cudaMalloc`) with its IPC handle.
+    ///
+    /// Use this when the caller already has a `cudaMalloc`'d pointer (e.g. from
+    /// a GPU kernel output) and wants to send it via Zenoh.
     pub fn from_device_ptr(ptr: *mut u8, len: usize, device_id: i32) -> ZResult<Self> {
         let ipc_handle = Self::get_ipc_handle(ptr, "from_device_ptr")?;
         Ok(Self {
@@ -275,18 +294,20 @@ mod tests {
     #[test]
     #[ignore = "requires CUDA device"]
     fn test_ipc_handle_serialize() {
-        let buf = CudaBufInner::alloc_pinned(512, 0).unwrap();
-        let handle = buf.ipc_handle;
-        let len = buf.cuda_len;
-        let device_id = buf.device_id;
+        // IPC handles are only valid for device memory (cudaMalloc), not pinned/unified.
+        let buf = CudaBufInner::alloc_device(512, 0).unwrap();
+        assert_eq!(buf.cuda_len, 512);
+        assert_eq!(buf.device_id, 0);
+        // IPC handle must be non-zero for real device memory.
+        assert_ne!(buf.ipc_handle, [0u8; 64], "IPC handle should be non-zero");
 
-        // Wrap in ZSlice
+        // Wrap in ZSlice and verify the kind can be set.
         let mut zslice = ZSlice::from(Arc::new(buf));
-        // Set kind to CudaPtr (normally done by publisher code)
         zslice.kind = ZSliceKind::CudaPtr;
+        assert!(zslice.kind == ZSliceKind::CudaPtr);
 
-        // Simulate codec round-trip: open IPC handle
-        let mapped = CudaBufInner::from_ipc(handle, len, device_id).unwrap();
-        assert_eq!(mapped.cuda_len, 512);
+        // Note: from_ipc is cross-process by design — opening in the same process
+        // will return cudaErrorInvalidResourceHandle (error 1). A full round-trip
+        // test requires two separate processes (see examples/cuda_pubsub.rs).
     }
 }

--- a/commons/zenoh-cuda/src/lib.rs
+++ b/commons/zenoh-cuda/src/lib.rs
@@ -1,0 +1,292 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+//! CUDA device memory support for Zenoh ZSlice transport.
+//!
+//! Provides [`CudaBufInner`]: a [`ZSliceBuffer`] backed by either:
+//! - **Pinned host memory** (`cudaMallocHost`): CPU-writable, DMA-accessible by GPU
+//! - **Unified memory** (`cudaMallocManaged`): accessible from both CPU and GPU
+//! - **Device-only memory** (`cudaMalloc`): GPU-only; `as_slice()` returns `&[]`
+//!
+//! The transport codec sends a 64-byte CUDA IPC handle instead of raw bytes,
+//! enabling zero-copy GPU tensor sharing between processes on the same host.
+
+use std::{any::Any, fmt};
+use zenoh_buffers::ZSliceBuffer;
+use zenoh_result::{zerror, ZResult};
+
+/// CUDA IPC memory handle — 64 bytes matching `cudaIpcMemHandle_t`.
+pub type CudaIpcHandle = [u8; 64];
+
+/// Discriminates how a [`CudaBufInner`] was allocated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CudaMemKind {
+    /// `cudaMallocHost` — pinned host memory. CPU-writable, fast GPU DMA.
+    Pinned,
+    /// `cudaMallocManaged` — unified memory. CPU and GPU accessible.
+    Unified,
+    /// `cudaMalloc` — device-only memory. `as_slice()` returns `&[]`.
+    Device,
+}
+
+/// CUDA Runtime API — error code for success.
+const CUDA_SUCCESS: i32 = 0;
+/// Flag for `cudaIpcOpenMemHandle`: enable lazy peer access.
+const CUDA_IPC_MEM_LAZY_ENABLE_PEER_ACCESS: u32 = 0x01;
+/// Flag for `cudaMallocManaged`: attach globally (accessible on all GPUs).
+const CUDA_MEM_ATTACH_GLOBAL: u32 = 0x01;
+
+// Raw CUDA Runtime API FFI — linked against libcudart at build time (see build.rs).
+extern "C" {
+    fn cudaSetDevice(device: i32) -> i32;
+    fn cudaMallocHost(ptr: *mut *mut u8, size: usize) -> i32;
+    fn cudaFreeHost(ptr: *mut u8) -> i32;
+    fn cudaMallocManaged(ptr: *mut *mut u8, size: usize, flags: u32) -> i32;
+    fn cudaFree(ptr: *mut u8) -> i32;
+    fn cudaIpcGetMemHandle(handle: *mut u8, dev_ptr: *mut u8) -> i32;
+    fn cudaIpcOpenMemHandle(dev_ptr: *mut *mut u8, handle: *const u8, flags: u32) -> i32;
+    fn cudaIpcCloseMemHandle(dev_ptr: *mut u8) -> i32;
+}
+
+fn check_cuda(ret: i32, op: &'static str) -> ZResult<()> {
+    if ret == CUDA_SUCCESS {
+        Ok(())
+    } else {
+        Err(zerror!("CUDA error {ret} in {op}").into())
+    }
+}
+
+/// A [`ZSliceBuffer`] backed by CUDA memory (pinned, unified, or device-only).
+///
+/// The transport codec sends a 64-byte IPC handle instead of raw bytes.
+/// On the subscriber side, the handle is opened via `from_ipc`.
+pub struct CudaBufInner {
+    /// CPU (or null for device-only) pointer to the allocation.
+    ptr: *mut u8,
+    /// Actual CUDA allocation size in bytes.
+    /// For device memory, `ZSlice::len()` returns 0; use `cuda_len()` directly.
+    pub cuda_len: usize,
+    /// 64-byte CUDA IPC handle identifying the allocation.
+    pub ipc_handle: CudaIpcHandle,
+    /// CUDA device ordinal that owns this allocation.
+    pub device_id: i32,
+    /// Memory kind (pinned / unified / device).
+    pub mem_kind: CudaMemKind,
+    /// True when this buffer was opened via `from_ipc` (subscriber side).
+    /// Drop will call `cudaIpcCloseMemHandle` instead of `cudaFree`/`cudaFreeHost`.
+    is_ipc_mapping: bool,
+}
+
+// SAFETY: CUDA IPC memory is not aliased between threads when accessed via
+// the IPC protocol; the ZSlice Arc ensures single-owner semantics.
+unsafe impl Send for CudaBufInner {}
+unsafe impl Sync for CudaBufInner {}
+
+impl CudaBufInner {
+    /// Allocate pinned host memory and register for CUDA IPC.
+    ///
+    /// Pinned memory is CPU-writable and GPU DMA-accessible. Suitable for
+    /// tensors that need occasional CPU writes (e.g. pre-processing on host).
+    pub fn alloc_pinned(len: usize, device_id: i32) -> ZResult<Self> {
+        let mut ptr: *mut u8 = std::ptr::null_mut();
+        unsafe {
+            check_cuda(cudaSetDevice(device_id), "cudaSetDevice")?;
+            check_cuda(cudaMallocHost(&mut ptr, len), "cudaMallocHost")?;
+        }
+        let ipc_handle = Self::get_ipc_handle(ptr, "alloc_pinned")?;
+        Ok(Self {
+            ptr,
+            cuda_len: len,
+            ipc_handle,
+            device_id,
+            mem_kind: CudaMemKind::Pinned,
+            is_ipc_mapping: false,
+        })
+    }
+
+    /// Allocate unified memory (`cudaMallocManaged`).
+    ///
+    /// Unified memory is CPU- and GPU-accessible. Best for tensors that are
+    /// written on CPU and consumed on GPU (or vice versa), at the cost of
+    /// page-migration overhead on first access.
+    pub fn alloc_unified(len: usize, device_id: i32) -> ZResult<Self> {
+        let mut ptr: *mut u8 = std::ptr::null_mut();
+        unsafe {
+            check_cuda(cudaSetDevice(device_id), "cudaSetDevice")?;
+            check_cuda(
+                cudaMallocManaged(&mut ptr, len, CUDA_MEM_ATTACH_GLOBAL),
+                "cudaMallocManaged",
+            )?;
+        }
+        let ipc_handle = Self::get_ipc_handle(ptr, "alloc_unified")?;
+        Ok(Self {
+            ptr,
+            cuda_len: len,
+            ipc_handle,
+            device_id,
+            mem_kind: CudaMemKind::Unified,
+            is_ipc_mapping: false,
+        })
+    }
+
+    /// Wrap an existing device-only allocation (`cudaMalloc`).
+    ///
+    /// `as_slice()` returns `&[]` for this kind — the buffer can only be
+    /// accessed by GPU kernels. The IPC handle encodes the allocation pointer.
+    pub fn from_device_ptr(ptr: *mut u8, len: usize, device_id: i32) -> ZResult<Self> {
+        let ipc_handle = Self::get_ipc_handle(ptr, "from_device_ptr")?;
+        Ok(Self {
+            ptr,
+            cuda_len: len,
+            ipc_handle,
+            device_id,
+            mem_kind: CudaMemKind::Device,
+            is_ipc_mapping: false,
+        })
+    }
+
+    /// Reconstruct a buffer on the subscriber side by opening a CUDA IPC handle.
+    ///
+    /// The returned buffer's `ptr` is a device pointer mapped from the handle.
+    /// `as_slice()` returns `&[]`; access must go through GPU kernels.
+    pub fn from_ipc(handle: CudaIpcHandle, cuda_len: usize, device_id: i32) -> ZResult<Self> {
+        let mut ptr: *mut u8 = std::ptr::null_mut();
+        unsafe {
+            check_cuda(cudaSetDevice(device_id), "cudaSetDevice")?;
+            check_cuda(
+                cudaIpcOpenMemHandle(
+                    &mut ptr,
+                    handle.as_ptr(),
+                    CUDA_IPC_MEM_LAZY_ENABLE_PEER_ACCESS,
+                ),
+                "cudaIpcOpenMemHandle",
+            )?;
+        }
+        Ok(Self {
+            ptr,
+            cuda_len,
+            ipc_handle: handle,
+            device_id,
+            mem_kind: CudaMemKind::Device,
+            is_ipc_mapping: true,
+        })
+    }
+
+    /// Return the raw device (or host, for pinned/unified) pointer.
+    ///
+    /// # Safety
+    /// The pointer is valid until this `CudaBufInner` is dropped.
+    pub fn as_device_ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    fn get_ipc_handle(ptr: *mut u8, ctx: &'static str) -> ZResult<CudaIpcHandle> {
+        let mut handle = [0u8; 64];
+        unsafe {
+            check_cuda(cudaIpcGetMemHandle(handle.as_mut_ptr(), ptr), ctx)?;
+        }
+        Ok(handle)
+    }
+}
+
+impl ZSliceBuffer for CudaBufInner {
+    fn as_slice(&self) -> &[u8] {
+        match self.mem_kind {
+            CudaMemKind::Pinned | CudaMemKind::Unified => {
+                // SAFETY: ptr is valid CPU-accessible memory for the lifetime of self.
+                unsafe { std::slice::from_raw_parts(self.ptr, self.cuda_len) }
+            }
+            CudaMemKind::Device => {
+                // Device memory is not CPU-addressable. The codec bypasses as_slice()
+                // for ZSliceKind::CudaPtr, so this branch should rarely be reached.
+                // Return empty slice rather than panicking to keep ZSlice::new() sane.
+                &[]
+            }
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+impl Drop for CudaBufInner {
+    fn drop(&mut self) {
+        if self.ptr.is_null() {
+            return;
+        }
+        let ret = unsafe {
+            match (self.mem_kind, self.is_ipc_mapping) {
+                (_, true) => cudaIpcCloseMemHandle(self.ptr),
+                (CudaMemKind::Pinned, false) => cudaFreeHost(self.ptr),
+                (CudaMemKind::Unified | CudaMemKind::Device, false) => cudaFree(self.ptr),
+            }
+        };
+        if ret != CUDA_SUCCESS {
+            tracing::error!("CUDA free error {ret} dropping CudaBufInner");
+        }
+    }
+}
+
+impl fmt::Debug for CudaBufInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CudaBufInner {{ cuda_len: {}, device_id: {}, mem_kind: {:?}, is_ipc: {} }}",
+            self.cuda_len, self.device_id, self.mem_kind, self.is_ipc_mapping
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use zenoh_buffers::{ZSlice, ZSliceKind};
+
+    #[test]
+    #[ignore = "requires CUDA device"]
+    fn test_pinned_alloc_roundtrip() {
+        let mut buf = CudaBufInner::alloc_pinned(1024, 0).unwrap();
+        // Write via CPU
+        let slice = unsafe { std::slice::from_raw_parts_mut(buf.as_device_ptr(), buf.cuda_len) };
+        slice[0] = 0xDE;
+        slice[1] = 0xAD;
+
+        // Read via as_slice()
+        assert_eq!(buf.as_slice()[0], 0xDE);
+        assert_eq!(buf.as_slice()[1], 0xAD);
+    }
+
+    #[test]
+    #[ignore = "requires CUDA device"]
+    fn test_ipc_handle_serialize() {
+        let buf = CudaBufInner::alloc_pinned(512, 0).unwrap();
+        let handle = buf.ipc_handle;
+        let len = buf.cuda_len;
+        let device_id = buf.device_id;
+
+        // Wrap in ZSlice
+        let mut zslice = ZSlice::from(Arc::new(buf));
+        // Set kind to CudaPtr (normally done by publisher code)
+        zslice.kind = ZSliceKind::CudaPtr;
+
+        // Simulate codec round-trip: open IPC handle
+        let mapped = CudaBufInner::from_ipc(handle, len, device_id).unwrap();
+        assert_eq!(mapped.cuda_len, 512);
+    }
+}

--- a/commons/zenoh-cuda/src/lib.rs
+++ b/commons/zenoh-cuda/src/lib.rs
@@ -86,6 +86,8 @@ pub struct CudaBufInner {
     /// True when this buffer was opened via `from_ipc` (subscriber side).
     /// Drop will call `cudaIpcCloseMemHandle` instead of `cudaFree`/`cudaFreeHost`.
     is_ipc_mapping: bool,
+    /// False for borrowed pointers (e.g. from torch allocator) — Drop skips cudaFree.
+    owns_allocation: bool,
 }
 
 // SAFETY: CUDA IPC memory is not aliased between threads when accessed via
@@ -111,6 +113,7 @@ impl CudaBufInner {
             device_id,
             mem_kind: CudaMemKind::Pinned,
             is_ipc_mapping: false,
+            owns_allocation: true,
         })
     }
 
@@ -134,6 +137,7 @@ impl CudaBufInner {
             device_id,
             mem_kind: CudaMemKind::Unified,
             is_ipc_mapping: false,
+            owns_allocation: true,
         })
     }
 
@@ -155,6 +159,7 @@ impl CudaBufInner {
             device_id,
             mem_kind: CudaMemKind::Device,
             is_ipc_mapping: false,
+            owns_allocation: true,
         })
     }
 
@@ -162,6 +167,7 @@ impl CudaBufInner {
     ///
     /// Use this when the caller already has a `cudaMalloc`'d pointer (e.g. from
     /// a GPU kernel output) and wants to send it via Zenoh.
+    /// The returned buffer **takes ownership** and will call `cudaFree` on drop.
     pub fn from_device_ptr(ptr: *mut u8, len: usize, device_id: i32) -> ZResult<Self> {
         let ipc_handle = Self::get_ipc_handle(ptr, "from_device_ptr")?;
         Ok(Self {
@@ -171,6 +177,32 @@ impl CudaBufInner {
             device_id,
             mem_kind: CudaMemKind::Device,
             is_ipc_mapping: false,
+            owns_allocation: true,
+        })
+    }
+
+    /// Wrap an externally-owned device pointer **without taking ownership**.
+    ///
+    /// Use this when the pointer is managed by an external allocator (e.g. the
+    /// PyTorch CUDA caching allocator) that must remain responsible for freeing
+    /// the memory. Drop will NOT call `cudaFree`.
+    ///
+    /// The caller must ensure the source allocation outlives this buffer and any
+    /// ZBuf/ZSlice referencing it (i.e. until after the publish call completes).
+    ///
+    /// # Safety
+    /// `ptr` must be a valid `cudaMalloc`'d device pointer for `len` bytes on
+    /// the given `device_id`. It must remain valid until this `CudaBufInner` drops.
+    pub fn from_device_ptr_borrowed(ptr: *mut u8, len: usize, device_id: i32) -> ZResult<Self> {
+        let ipc_handle = Self::get_ipc_handle(ptr, "from_device_ptr_borrowed")?;
+        Ok(Self {
+            ptr,
+            cuda_len: len,
+            ipc_handle,
+            device_id,
+            mem_kind: CudaMemKind::Device,
+            is_ipc_mapping: false,
+            owns_allocation: false,
         })
     }
 
@@ -198,6 +230,7 @@ impl CudaBufInner {
             device_id,
             mem_kind: CudaMemKind::Device,
             is_ipc_mapping: true,
+            owns_allocation: true,
         })
     }
 
@@ -245,7 +278,7 @@ impl ZSliceBuffer for CudaBufInner {
 
 impl Drop for CudaBufInner {
     fn drop(&mut self) {
-        if self.ptr.is_null() {
+        if self.ptr.is_null() || !self.owns_allocation {
             return;
         }
         let ret = unsafe {
@@ -265,8 +298,8 @@ impl fmt::Debug for CudaBufInner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "CudaBufInner {{ cuda_len: {}, device_id: {}, mem_kind: {:?}, is_ipc: {} }}",
-            self.cuda_len, self.device_id, self.mem_kind, self.is_ipc_mapping
+            "CudaBufInner {{ cuda_len: {}, device_id: {}, mem_kind: {:?}, is_ipc: {}, owned: {} }}",
+            self.cuda_len, self.device_id, self.mem_kind, self.is_ipc_mapping, self.owns_allocation
         )
     }
 }

--- a/commons/zenoh-cuda/src/lib.rs
+++ b/commons/zenoh-cuda/src/lib.rs
@@ -28,6 +28,14 @@ use zenoh_result::{zerror, ZResult};
 /// CUDA IPC memory handle — 64 bytes matching `cudaIpcMemHandle_t`.
 pub type CudaIpcHandle = [u8; 64];
 
+/// FFI wrapper for `cudaIpcMemHandle_t` passed by value.
+///
+/// The CUDA Runtime API `cudaIpcOpenMemHandle` expects the handle as a
+/// by-value struct (64 bytes on the stack per the x86-64 SysV ABI), not
+/// as a pointer.  This `#[repr(C)]` newtype lets Rust pass it correctly.
+#[repr(C)]
+struct CudaIpcMemHandleFfi([u8; 64]);
+
 /// Discriminates how a [`CudaBufInner`] was allocated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CudaMemKind {
@@ -55,7 +63,10 @@ extern "C" {
     fn cudaMallocManaged(ptr: *mut *mut u8, size: usize, flags: u32) -> i32;
     fn cudaFree(ptr: *mut u8) -> i32;
     fn cudaIpcGetMemHandle(handle: *mut u8, dev_ptr: *mut u8) -> i32;
-    fn cudaIpcOpenMemHandle(dev_ptr: *mut *mut u8, handle: *const u8, flags: u32) -> i32;
+    // NOTE: cudaIpcMemHandle_t is a 64-byte struct passed BY VALUE in C.
+    // Using CudaIpcMemHandleFfi (#[repr(C)]) ensures Rust follows the x86-64
+    // SysV ABI (MEMORY class → 64 bytes on the stack), not pointer-passing.
+    fn cudaIpcOpenMemHandle(dev_ptr: *mut *mut u8, handle: CudaIpcMemHandleFfi, flags: u32) -> i32;
     fn cudaIpcCloseMemHandle(dev_ptr: *mut u8) -> i32;
 }
 
@@ -217,7 +228,7 @@ impl CudaBufInner {
             check_cuda(
                 cudaIpcOpenMemHandle(
                     &mut ptr,
-                    handle.as_ptr(),
+                    CudaIpcMemHandleFfi(handle),
                     CUDA_IPC_MEM_LAZY_ENABLE_PEER_ACCESS,
                 ),
                 "cudaIpcOpenMemHandle",

--- a/commons/zenoh-mem-transport/Cargo.toml
+++ b/commons/zenoh-mem-transport/Cargo.toml
@@ -14,43 +14,24 @@
 [package]
 authors = { workspace = true }
 categories = { workspace = true }
-description = "Internal crate for zenoh."
+description = "Pluggable zero-copy memory transport backends for zenoh (SHM, CUDA IPC, RDMA, …)."
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
-name = "zenoh-protocol"
+name = "zenoh-mem-transport"
 repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
 [features]
 default = ["std"]
-internal = []
-shared-memory = ["std", "zenoh-buffers/shared-memory"]
-std = [
-  "rand?/std",
-  "rand?/std_rng",
-  "serde/std",
-  "uhlc/std",
-  "zenoh-buffers/std",
-  "zenoh-keyexpr/std",
-  "zenoh-result/std",
-]
-test = ["rand", "zenoh-buffers/test"]
-unstable = []
-cuda = []
+std = []
+shared-memory = ["zenoh-buffers/shared-memory", "dep:zenoh-shm"]
+cuda = ["shared-memory", "zenoh-buffers/cuda", "dep:zenoh-cuda"]
 
 [dependencies]
-const_format = { workspace = true }
-rand = { workspace = true, features = ["alloc", "getrandom"], optional = true }
-serde = { workspace = true, features = ["alloc"] }
-uhlc = { workspace = true, default-features = false }
 zenoh-buffers = { workspace = true, default-features = false }
-zenoh-keyexpr = { workspace = true }
-zenoh-macros = { workspace = true }
 zenoh-result = { workspace = true }
-
-# NOTE: May cause problems when testing no_std stuff. Check this tool: https://docs.rs/crate/cargo-no-dev-deps/0.1.0
-[dev-dependencies]
-lazy_static = { workspace = true }
-rand = { workspace = true, features = ["default"] }
+tracing = { workspace = true }
+zenoh-shm = { workspace = true, optional = true }
+zenoh-cuda = { workspace = true, optional = true }

--- a/commons/zenoh-mem-transport/examples/registry_negotiate.rs
+++ b/commons/zenoh-mem-transport/examples/registry_negotiate.rs
@@ -1,0 +1,109 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! # Example: capability negotiation with `MemRegistry`
+//!
+//! Shows how a session startup routine would:
+//!
+//! 1. Register SHM (and optionally CUDA) backends in a [`MemRegistry`].
+//! 2. Build the local `ext_mem` bytes to advertise in `InitSyn`.
+//! 3. Parse a peer's `ext_mem` bytes and call [`MemRegistry::negotiate`] to
+//!    obtain a [`NegotiatedMemCaps`] for the connection.
+//! 4. Query the outcome per [`ZSliceKind`] at TX time.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example registry_negotiate --features shared-memory
+//! ```
+
+use std::sync::Arc;
+
+use zenoh_buffers::ZSliceKind;
+use zenoh_mem_transport::{
+    backends::shm::ShmBackend,
+    caps::{MemBackendCaps, MemInitExt, MemPeerCaps, ShmCaps},
+    DowngradePath, MemRegistry, NegotiationResult,
+};
+
+fn main() {
+    // ── 1. Build a local registry ────────────────────────────────────────────
+    //
+    // At session startup, register the backends you want to use.
+    // The registry is shared (Arc) across all transport connections.
+
+    let mut registry = MemRegistry::new();
+
+    // SHM backend: segment ID 1, supports POSIX protocol (ID = 0).
+    registry.register(ShmBackend::new(1, vec![0]));
+
+    // (CUDA backend would be registered here when the `cuda` feature is active.)
+    //   #[cfg(feature = "cuda")]
+    //   registry.register(CudaIpcBackend::new(vec![0, 1]));
+
+    let registry = Arc::new(registry);
+
+    println!("Local backends: {} registered", registry.local_caps().len());
+
+    // ── 2. Serialize local caps into ext_mem bytes ───────────────────────────
+    //
+    // This is what MemFsm::local_ext() does inside zenoh-transport.
+
+    let local_ext = MemInitExt::new(registry.local_caps());
+    let bytes = local_ext.to_bytes();
+    println!("ext_mem bytes ({} bytes): {bytes:?}", bytes.len());
+
+    // ── 3. Simulate receiving a peer's ext_mem (both have SHM) ───────────────
+
+    let peer_ext_bytes = {
+        let peer_ext = MemInitExt::new(vec![MemBackendCaps::Shm(ShmCaps { segment_id: 99 })]);
+        peer_ext.to_bytes()
+    };
+
+    let parsed_peer =
+        MemInitExt::from_bytes(&peer_ext_bytes).expect("peer's ext_mem should parse");
+
+    let peer_caps = MemPeerCaps::new(parsed_peer.backends);
+    let negotiated = registry.negotiate(&peer_caps);
+
+    // ── 4. Query negotiation outcome at TX time ───────────────────────────────
+
+    match negotiated.get(ZSliceKind::ShmPtr) {
+        Some(entry) => match &entry.result {
+            NegotiationResult::Native => println!("ShmPtr: Native zero-copy"),
+            NegotiationResult::Fallback(DowngradePath::ToRaw) => {
+                println!("ShmPtr: Fallback — copy to raw bytes")
+            }
+            NegotiationResult::Fallback(DowngradePath::ToShm) => {
+                println!("ShmPtr: Fallback — copy into SHM region")
+            }
+            NegotiationResult::Reject => println!("ShmPtr: Rejected"),
+        },
+        None => println!("ShmPtr: No backend registered"),
+    }
+
+    // ── 5. Peer with no memory backends (raw-only node) ──────────────────────
+
+    let raw_peer = MemPeerCaps::new(vec![]);
+    let negotiated_raw = registry.negotiate(&raw_peer);
+    match negotiated_raw.get(ZSliceKind::ShmPtr) {
+        Some(entry) => match &entry.result {
+            NegotiationResult::Fallback(DowngradePath::ToRaw) => {
+                println!("Raw-only peer: ShmPtr → fallback to raw (expected)")
+            }
+            other => println!("Unexpected result for raw peer: {other:?}"),
+        },
+        None => println!("ShmPtr: No backend registered"),
+    }
+}

--- a/commons/zenoh-mem-transport/src/backends/cuda.rs
+++ b/commons/zenoh-mem-transport/src/backends/cuda.rs
@@ -1,0 +1,115 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! [`CudaIpcBackend`]: ZeroMemTransport implementation for CUDA IPC.
+//!
+//! Handles `ZSliceKind::CudaPtr` and `ZSliceKind::CudaTensor`.
+//!
+//! ## Downgrade paths
+//!
+//! When the remote peer does not support CUDA IPC (e.g. a non-CUDA subscriber,
+//! or a subscriber on a different host), the backend can fall back:
+//!
+//! - [`DowngradePath::ToRaw`]: allocates a host staging buffer and copies GPU→host
+//!   via `cudaMemcpy DeviceToHost`, then sends as `ZSliceKind::Raw`.
+//! - [`DowngradePath::ToShm`]: reserved for future use (GPU→SHM mapping).
+
+use std::sync::Arc;
+
+use zenoh_buffers::{ZSlice, ZSliceBuffer, ZSliceKind};
+use zenoh_cuda::CudaBufInner;
+use zenoh_result::{zerror, ZResult};
+
+use crate::{
+    caps::{CudaIpcCaps, MemBackendCaps, MemBackendId},
+    transport::{DowngradePath, HandleReader, HandleWriter, NegotiationResult, ZeroMemTransport},
+};
+
+/// [`ZeroMemTransport`] backend for CUDA IPC (same-host zero-copy GPU transport).
+pub struct CudaIpcBackend {
+    /// Device IDs this peer can share from (empty = current device only).
+    local_device_ids: Vec<i32>,
+}
+
+impl CudaIpcBackend {
+    /// Create a backend advertising the given device IDs.
+    pub fn new(device_ids: Vec<i32>) -> Arc<Self> {
+        Arc::new(Self {
+            local_device_ids: device_ids,
+        })
+    }
+}
+
+impl ZeroMemTransport for CudaIpcBackend {
+    fn owned_kinds(&self) -> &[ZSliceKind] {
+        &[ZSliceKind::CudaPtr, ZSliceKind::CudaTensor]
+    }
+
+    fn backend_id(&self) -> MemBackendId {
+        MemBackendId::CudaIpc
+    }
+
+    fn local_caps(&self) -> MemBackendCaps {
+        MemBackendCaps::CudaIpc(CudaIpcCaps {
+            device_ids: self.local_device_ids.clone(),
+        })
+    }
+
+    fn negotiate(&self, peer: Option<&MemBackendCaps>) -> NegotiationResult {
+        match peer {
+            Some(MemBackendCaps::CudaIpc(_)) => NegotiationResult::Native,
+            Some(MemBackendCaps::Shm(_)) => NegotiationResult::Fallback(DowngradePath::ToShm),
+            _ => NegotiationResult::Fallback(DowngradePath::ToRaw),
+        }
+    }
+
+    fn write_handle(&self, zs: &ZSlice, writer: &mut dyn HandleWriter) -> ZResult<()> {
+        // Encoding is still handled by the codec in zenoh-codec/src/core/zbuf.rs
+        // for Phase 1/2. This will be fully migrated in Phase 3.
+        let _ = (zs, writer);
+        Err(zerror!("CudaIpcBackend::write_handle: codec handles encoding (Phase 3 pending)").into())
+    }
+
+    fn read_handle(&self, reader: &mut dyn HandleReader, kind: ZSliceKind) -> ZResult<ZSlice> {
+        let _ = (reader, kind);
+        Err(zerror!("CudaIpcBackend::read_handle: codec handles decoding (Phase 3 pending)").into())
+    }
+
+    fn downgrade(&self, zs: &ZSlice, path: DowngradePath) -> Option<ZSlice> {
+        let cuda = zs.downcast_ref::<CudaBufInner>()?;
+        match path {
+            DowngradePath::ToRaw => {
+                // Allocate a host staging buffer and cudaMemcpy device→host.
+                let mut staging = vec![0u8; cuda.cuda_len];
+                if let Err(e) = cuda.copy_to_host(&mut staging) {
+                    tracing::error!("CudaIpcBackend downgrade ToRaw: cudaMemcpy failed: {e}");
+                    return None;
+                }
+                // Wrap in Arc<Vec<u8>> which implements ZSliceBuffer.
+                let arc: Arc<dyn ZSliceBuffer> = Arc::new(staging);
+                let len = arc.as_slice().len();
+                ZSlice::new(arc, 0, len).ok()
+            }
+            DowngradePath::ToShm => {
+                // TODO Phase 4: copy into an SHM-mapped region.
+                // Requires a reference to the session's ShmProvider.
+                // For now, fall back to raw bytes.
+                tracing::warn!(
+                    "CudaIpcBackend downgrade ToShm: SHM staging not yet implemented, using raw"
+                );
+                self.downgrade(zs, DowngradePath::ToRaw)
+            }
+        }
+    }
+}

--- a/commons/zenoh-mem-transport/src/backends/mod.rs
+++ b/commons/zenoh-mem-transport/src/backends/mod.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 ZettaScale Technology
+// Copyright (c) 2023 ZettaScale Technology
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
@@ -11,17 +11,9 @@
 // Contributors:
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
-#[cfg(feature = "transport_auth")]
-pub mod auth;
-#[cfg(feature = "transport_compression")]
-pub(crate) mod compression;
-pub(crate) mod lowlatency;
-#[cfg(feature = "transport_multilink")]
-pub(crate) mod multilink;
-pub(crate) mod patch;
-pub(crate) mod qos;
+
 #[cfg(feature = "shared-memory")]
-pub(crate) mod shm;
+pub mod shm;
 
 #[cfg(feature = "cuda")]
-pub(crate) mod mem;
+pub mod cuda;

--- a/commons/zenoh-mem-transport/src/backends/shm.rs
+++ b/commons/zenoh-mem-transport/src/backends/shm.rs
@@ -1,0 +1,91 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! [`ShmBackend`]: ZeroMemTransport implementation for POSIX shared memory.
+//!
+//! Wraps the existing SHM auth/protocol machinery.  The challenge-response
+//! handshake (OpenSyn/OpenAck) is still driven by the establishment FSM in
+//! `zenoh-transport`; this backend only participates in capability advertisement
+//! (`local_caps`) and per-kind negotiation (`negotiate`).
+
+use std::sync::Arc;
+
+use zenoh_buffers::{ZSlice, ZSliceKind};
+use zenoh_result::{zerror, ZResult};
+use zenoh_shm::api::common::types::ProtocolID;
+
+use crate::{
+    caps::{MemBackendCaps, MemBackendId, ShmCaps},
+    transport::{DowngradePath, HandleReader, HandleWriter, NegotiationResult, ZeroMemTransport},
+};
+
+/// [`ZeroMemTransport`] backend for POSIX shared memory.
+pub struct ShmBackend {
+    /// Our local AuthSegment ID, advertised in `ext_mem` during InitSyn.
+    pub segment_id: u64,
+    /// Protocol IDs the local SHM provider supports (e.g. POSIX = 0).
+    pub supported_protocols: Vec<ProtocolID>,
+}
+
+impl ShmBackend {
+    pub fn new(segment_id: u64, supported_protocols: Vec<ProtocolID>) -> Arc<Self> {
+        Arc::new(Self {
+            segment_id,
+            supported_protocols,
+        })
+    }
+}
+
+impl ZeroMemTransport for ShmBackend {
+    fn owned_kinds(&self) -> &[ZSliceKind] {
+        &[ZSliceKind::ShmPtr]
+    }
+
+    fn backend_id(&self) -> MemBackendId {
+        MemBackendId::Shm
+    }
+
+    fn local_caps(&self) -> MemBackendCaps {
+        MemBackendCaps::Shm(ShmCaps {
+            segment_id: self.segment_id,
+        })
+    }
+
+    fn negotiate(&self, peer: Option<&MemBackendCaps>) -> NegotiationResult {
+        match peer {
+            Some(MemBackendCaps::Shm(_)) => NegotiationResult::Native,
+            _ => NegotiationResult::Fallback(DowngradePath::ToRaw),
+        }
+    }
+
+    fn write_handle(&self, zs: &ZSlice, writer: &mut dyn HandleWriter) -> ZResult<()> {
+        // The SHM wire format is: the ShmBufInfo encoded as a ZSlice of bytes.
+        // The codec in zenoh-codec/src/core/zbuf.rs already handles this for ShmPtr.
+        // This method is a no-op placeholder — the actual encoding lives in the codec
+        // for now and will be migrated here in Phase 3.
+        let _ = (zs, writer);
+        Err(zerror!("ShmBackend::write_handle: use codec directly (Phase 3 migration pending)").into())
+    }
+
+    fn read_handle(&self, reader: &mut dyn HandleReader, kind: ZSliceKind) -> ZResult<ZSlice> {
+        let _ = (reader, kind);
+        Err(zerror!("ShmBackend::read_handle: use codec directly (Phase 3 migration pending)").into())
+    }
+
+    fn downgrade(&self, _zs: &ZSlice, _path: DowngradePath) -> Option<ZSlice> {
+        // SHM is already a fallback target; it does not further downgrade.
+        // (Raw bytes are handled by the codec as ZSliceKind::Raw, not by a backend.)
+        None
+    }
+}

--- a/commons/zenoh-mem-transport/src/caps.rs
+++ b/commons/zenoh-mem-transport/src/caps.rs
@@ -1,0 +1,253 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! Capability types for the `ext_mem` handshake extension.
+
+use zenoh_buffers::ZSliceKind;
+
+/// Wire identifier for each known backend.
+///
+/// Adding a new backend requires a protocol version bump and a new variant here.
+/// Closed enum by design: the wire format must be stable and exhaustive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum MemBackendId {
+    Shm = 0,
+    CudaIpc = 1,
+    Rdma = 2, // reserved — not yet implemented
+}
+
+impl MemBackendId {
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(Self::Shm),
+            1 => Some(Self::CudaIpc),
+            2 => Some(Self::Rdma),
+            _ => None,
+        }
+    }
+}
+
+/// Backend-specific capability data advertised during the handshake.
+#[derive(Debug, Clone)]
+pub enum MemBackendCaps {
+    /// POSIX SHM: the auth segment ID (u64) for the challenge-response handshake.
+    Shm(ShmCaps),
+    /// CUDA IPC: list of device ordinals the peer can share from.
+    CudaIpc(CudaIpcCaps),
+    /// RDMA: reserved placeholder.
+    Rdma(RdmaCaps),
+}
+
+impl MemBackendCaps {
+    pub fn id(&self) -> MemBackendId {
+        match self {
+            Self::Shm(_) => MemBackendId::Shm,
+            Self::CudaIpc(_) => MemBackendId::CudaIpc,
+            Self::Rdma(_) => MemBackendId::Rdma,
+        }
+    }
+}
+
+/// SHM capability: the initiator's auth segment ID used for challenge-response.
+#[derive(Debug, Clone)]
+pub struct ShmCaps {
+    /// AuthSegment ID sent in InitSyn (equivalent to the old `ext_shm` payload).
+    pub segment_id: u64,
+}
+
+/// CUDA IPC capability: device ordinals available on this peer.
+#[derive(Debug, Clone)]
+pub struct CudaIpcCaps {
+    pub device_ids: Vec<i32>,
+}
+
+/// RDMA capability: reserved for future use.
+#[derive(Debug, Clone)]
+pub struct RdmaCaps {
+    _reserved: (),
+}
+
+/// Capabilities advertised by a remote peer in `ext_mem`.
+///
+/// Built from the decoded `InitSyn`/`InitAck` extension and stored for the
+/// lifetime of the transport connection.
+#[derive(Debug, Clone, Default)]
+pub struct MemPeerCaps {
+    backends: Vec<MemBackendCaps>,
+}
+
+impl MemPeerCaps {
+    pub fn new(backends: Vec<MemBackendCaps>) -> Self {
+        Self { backends }
+    }
+
+    /// Find this peer's capability for a given backend, if advertised.
+    pub fn find(&self, id: MemBackendId) -> Option<&MemBackendCaps> {
+        self.backends.iter().find(|c| c.id() == id)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &MemBackendCaps> {
+        self.backends.iter()
+    }
+}
+
+/// Result of handshake negotiation stored per transport connection.
+///
+/// Records, for each [`ZSliceKind`], what was agreed during the handshake.
+/// Used in `map_to_partner` on every TX message.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NegotiatedMemCaps {
+    // Indexed by ZSliceKind discriminant (u8).
+    // None = no backend registered for this kind (treat as Raw).
+    entries: Vec<Option<NegotiatedEntry>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NegotiatedEntry {
+    pub result: super::NegotiationResult,
+}
+
+impl NegotiatedMemCaps {
+    pub fn new() -> Self {
+        Self {
+            entries: vec![None; 8], // headroom for up to 8 ZSliceKind values
+        }
+    }
+
+    pub fn set(&mut self, kind: ZSliceKind, result: super::NegotiationResult) {
+        let idx = kind as usize;
+        if idx >= self.entries.len() {
+            self.entries.resize(idx + 1, None);
+        }
+        self.entries[idx] = Some(NegotiatedEntry { result });
+    }
+
+    pub fn get(&self, kind: ZSliceKind) -> Option<&NegotiatedEntry> {
+        self.entries.get(kind as usize)?.as_ref()
+    }
+}
+
+/// Wire format for the `ext_mem` handshake extension.
+///
+/// Serialized as bytes inside a `ZExtZBuf(0x8)`.
+/// Only carries non-SHM backends (CUDA IPC, RDMA, …).
+/// SHM capability is conveyed separately via the existing `ext_shm` extension.
+pub struct MemInitExt {
+    pub backends: Vec<MemBackendCaps>,
+}
+
+const WIRE_VERSION: u8 = 1;
+
+impl MemInitExt {
+    pub fn new(backends: Vec<MemBackendCaps>) -> Self {
+        Self { backends }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.push(WIRE_VERSION);
+        out.push(self.backends.len() as u8);
+        for backend in &self.backends {
+            match backend {
+                MemBackendCaps::CudaIpc(caps) => {
+                    out.push(MemBackendId::CudaIpc as u8);
+                    let n = caps.device_ids.len().min(255) as u8;
+                    let caps_len = 1u16 + n as u16 * 4;
+                    out.extend_from_slice(&caps_len.to_le_bytes());
+                    out.push(n);
+                    for &id in caps.device_ids.iter().take(n as usize) {
+                        out.extend_from_slice(&id.to_le_bytes());
+                    }
+                }
+                MemBackendCaps::Rdma(_) => {
+                    out.push(MemBackendId::Rdma as u8);
+                    out.extend_from_slice(&0u16.to_le_bytes());
+                }
+                MemBackendCaps::Shm(caps) => {
+                    out.push(MemBackendId::Shm as u8);
+                    let caps_len = 8u16;
+                    out.extend_from_slice(&caps_len.to_le_bytes());
+                    out.extend_from_slice(&caps.segment_id.to_le_bytes());
+                }
+            }
+        }
+        out
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.is_empty() {
+            return None;
+        }
+        let version = bytes[0];
+        if version != WIRE_VERSION {
+            return None;
+        }
+        if bytes.len() < 2 {
+            return None;
+        }
+        let n = bytes[1] as usize;
+        let mut pos = 2;
+        let mut backends = Vec::with_capacity(n);
+        for _ in 0..n {
+            if pos + 3 > bytes.len() {
+                return None;
+            }
+            let id = bytes[pos];
+            let len = u16::from_le_bytes([bytes[pos + 1], bytes[pos + 2]]) as usize;
+            pos += 3;
+            if pos + len > bytes.len() {
+                return None;
+            }
+            let cap_bytes = &bytes[pos..pos + len];
+            pos += len;
+            match id {
+                1 => {
+                    // CudaIpc
+                    if cap_bytes.is_empty() {
+                        return None;
+                    }
+                    let n_dev = cap_bytes[0] as usize;
+                    if 1 + n_dev * 4 > cap_bytes.len() {
+                        return None;
+                    }
+                    let mut device_ids = Vec::with_capacity(n_dev);
+                    for i in 0..n_dev {
+                        let off = 1 + i * 4;
+                        let v = i32::from_le_bytes([
+                            cap_bytes[off],
+                            cap_bytes[off + 1],
+                            cap_bytes[off + 2],
+                            cap_bytes[off + 3],
+                        ]);
+                        device_ids.push(v);
+                    }
+                    backends.push(MemBackendCaps::CudaIpc(CudaIpcCaps { device_ids }));
+                }
+                0 => {
+                    // Shm
+                    if cap_bytes.len() < 8 {
+                        return None;
+                    }
+                    let segment_id = u64::from_le_bytes(cap_bytes[..8].try_into().ok()?);
+                    backends.push(MemBackendCaps::Shm(ShmCaps { segment_id }));
+                }
+                _ => {
+                    // Unknown backend — skip
+                }
+            }
+        }
+        Some(Self { backends })
+    }
+}

--- a/commons/zenoh-mem-transport/src/caps.rs
+++ b/commons/zenoh-mem-transport/src/caps.rs
@@ -251,3 +251,146 @@ impl MemInitExt {
         Some(Self { backends })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DowngradePath, NegotiationResult};
+
+    // ── MemInitExt wire format ────────────────────────────────────────────────
+
+    #[test]
+    fn mem_init_ext_empty_roundtrip() {
+        let ext = MemInitExt::new(vec![]);
+        let bytes = ext.to_bytes();
+        // version byte + n_backends byte
+        assert_eq!(bytes.len(), 2);
+        let decoded = MemInitExt::from_bytes(&bytes).expect("decode failed");
+        assert!(decoded.backends.is_empty());
+    }
+
+    #[test]
+    fn mem_init_ext_shm_roundtrip() {
+        let ext = MemInitExt::new(vec![MemBackendCaps::Shm(ShmCaps { segment_id: 0xDEAD_BEEF_1234_5678 })]);
+        let bytes = ext.to_bytes();
+        let decoded = MemInitExt::from_bytes(&bytes).expect("decode failed");
+        assert_eq!(decoded.backends.len(), 1);
+        match &decoded.backends[0] {
+            MemBackendCaps::Shm(c) => assert_eq!(c.segment_id, 0xDEAD_BEEF_1234_5678),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mem_init_ext_cuda_roundtrip_no_devices() {
+        let ext = MemInitExt::new(vec![MemBackendCaps::CudaIpc(CudaIpcCaps { device_ids: vec![] })]);
+        let bytes = ext.to_bytes();
+        let decoded = MemInitExt::from_bytes(&bytes).expect("decode failed");
+        assert_eq!(decoded.backends.len(), 1);
+        match &decoded.backends[0] {
+            MemBackendCaps::CudaIpc(c) => assert!(c.device_ids.is_empty()),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mem_init_ext_cuda_roundtrip_multiple_devices() {
+        let ext = MemInitExt::new(vec![
+            MemBackendCaps::CudaIpc(CudaIpcCaps { device_ids: vec![0, 1, 2, -1] }),
+        ]);
+        let bytes = ext.to_bytes();
+        let decoded = MemInitExt::from_bytes(&bytes).expect("decode failed");
+        match &decoded.backends[0] {
+            MemBackendCaps::CudaIpc(c) => assert_eq!(c.device_ids, [0, 1, 2, -1]),
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mem_init_ext_multiple_backends_roundtrip() {
+        let ext = MemInitExt::new(vec![
+            MemBackendCaps::Shm(ShmCaps { segment_id: 42 }),
+            MemBackendCaps::CudaIpc(CudaIpcCaps { device_ids: vec![0, 1] }),
+        ]);
+        let bytes = ext.to_bytes();
+        let decoded = MemInitExt::from_bytes(&bytes).expect("decode failed");
+        assert_eq!(decoded.backends.len(), 2);
+        match &decoded.backends[0] {
+            MemBackendCaps::Shm(c) => assert_eq!(c.segment_id, 42),
+            other => panic!("expected Shm, got {other:?}"),
+        }
+        match &decoded.backends[1] {
+            MemBackendCaps::CudaIpc(c) => assert_eq!(c.device_ids, [0, 1]),
+            other => panic!("expected CudaIpc, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mem_init_ext_rejects_bad_version() {
+        let mut bytes = MemInitExt::new(vec![]).to_bytes();
+        bytes[0] = 99; // corrupt version
+        assert!(MemInitExt::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn mem_init_ext_rejects_truncated() {
+        // Truncate after version+n_backends but before first backend
+        let ext = MemInitExt::new(vec![MemBackendCaps::CudaIpc(CudaIpcCaps { device_ids: vec![0] })]);
+        let bytes = ext.to_bytes();
+        assert!(MemInitExt::from_bytes(&bytes[..3]).is_none()); // header only, no caps
+    }
+
+    #[test]
+    fn mem_init_ext_skips_unknown_backend_id() {
+        // Manually craft a payload with an unknown backend id (0x42)
+        let mut bytes = vec![
+            1u8,    // version
+            2u8,    // n_backends = 2
+            0x42,   // unknown id
+            3, 0,   // len = 3
+            0, 0, 0,// 3 bytes of garbage
+            1u8,    // CudaIpc id
+            1, 0,   // len = 1
+            0u8,    // n_devices = 0
+        ];
+        let _ = bytes; // suppress unused warning; use directly
+        let decoded = MemInitExt::from_bytes(&bytes).expect("should succeed, skipping unknown");
+        // Only the known CudaIpc backend should appear
+        assert_eq!(decoded.backends.len(), 1);
+        assert!(matches!(decoded.backends[0], MemBackendCaps::CudaIpc(_)));
+    }
+
+    // ── NegotiatedMemCaps ─────────────────────────────────────────────────────
+
+    #[test]
+    fn negotiated_mem_caps_set_and_get() {
+        use zenoh_buffers::ZSliceKind;
+        let mut caps = NegotiatedMemCaps::new();
+        caps.set(ZSliceKind::ShmPtr, NegotiationResult::Native);
+        let entry = caps.get(ZSliceKind::ShmPtr).expect("should be present");
+        assert!(matches!(entry.result, NegotiationResult::Native));
+        assert!(caps.get(ZSliceKind::Raw).is_none());
+    }
+
+    #[test]
+    fn negotiated_mem_caps_fallback() {
+        use zenoh_buffers::ZSliceKind;
+        let mut caps = NegotiatedMemCaps::new();
+        caps.set(ZSliceKind::ShmPtr, NegotiationResult::Fallback(DowngradePath::ToRaw));
+        let entry = caps.get(ZSliceKind::ShmPtr).expect("should be present");
+        assert!(matches!(entry.result, NegotiationResult::Fallback(DowngradePath::ToRaw)));
+    }
+
+    // ── MemPeerCaps ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn mem_peer_caps_find() {
+        let peer = MemPeerCaps::new(vec![
+            MemBackendCaps::Shm(ShmCaps { segment_id: 1 }),
+            MemBackendCaps::CudaIpc(CudaIpcCaps { device_ids: vec![0] }),
+        ]);
+        assert!(peer.find(MemBackendId::Shm).is_some());
+        assert!(peer.find(MemBackendId::CudaIpc).is_some());
+        assert!(peer.find(MemBackendId::Rdma).is_none());
+    }
+}

--- a/commons/zenoh-mem-transport/src/lib.rs
+++ b/commons/zenoh-mem-transport/src/lib.rs
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! Pluggable zero-copy memory transport backends for Zenoh.
+//!
+//! # Overview
+//!
+//! SHM, CUDA IPC, RDMA, and UCX all follow the same pattern:
+//!
+//! ```text
+//! Publisher:  allocate in shared space  →  get a handle (small, opaque bytes)
+//! Wire:       send the handle only      →  no bulk data transfer
+//! Subscriber: open the handle           →  zero-copy view of the same memory
+//! ```
+//!
+//! This crate defines [`ZeroMemTransport`], the common trait for all backends,
+//! and [`MemRegistry`], the runtime registry that the transport layer uses to
+//! dispatch encoding/decoding and fallback conversions.
+//!
+//! # Capability negotiation
+//!
+//! During the Zenoh handshake (`InitSyn`/`InitAck`/`OpenSyn`/`OpenAck`) each
+//! peer advertises a [`MemPeerCaps`] listing which backends it supports.  After
+//! the handshake the transport stores a [`NegotiatedMemCaps`] that records, for
+//! each [`ZSliceKind`], whether to use the backend natively or to fall back to
+//! a cheaper representation the peer can receive.
+//!
+//! # Adding a new backend
+//!
+//! 1. Implement [`ZeroMemTransport`] in a new crate (e.g. `zenoh-rdma`).
+//! 2. Add a `MemBackendId` variant (protocol version bump).
+//! 3. Register with [`MemRegistry::register`] at session startup.
+//! 4. No changes to `map_to_partner`, codec dispatch, or the handshake FSM.
+
+pub mod backends;
+pub mod caps;
+pub mod registry;
+pub mod transport;
+
+pub use caps::{MemBackendCaps, MemBackendId, MemInitExt, MemPeerCaps, NegotiatedMemCaps};
+pub use registry::MemRegistry;
+pub use transport::{DowngradePath, NegotiationResult, ZeroMemTransport};

--- a/commons/zenoh-mem-transport/src/lib.rs
+++ b/commons/zenoh-mem-transport/src/lib.rs
@@ -30,18 +30,48 @@
 //!
 //! # Capability negotiation
 //!
-//! During the Zenoh handshake (`InitSyn`/`InitAck`/`OpenSyn`/`OpenAck`) each
-//! peer advertises a [`MemPeerCaps`] listing which backends it supports.  After
-//! the handshake the transport stores a [`NegotiatedMemCaps`] that records, for
-//! each [`ZSliceKind`], whether to use the backend natively or to fall back to
-//! a cheaper representation the peer can receive.
+//! During the Zenoh handshake (`InitSyn`/`InitAck`) each peer advertises which
+//! backends it supports via the `ext_mem` extension (extension ID `0x8`).
+//!
+//! - SHM capability is already conveyed by the existing `ext_shm` (ID `0x2`)
+//!   and its challenge-response mechanism; `ext_mem` carries additional backends
+//!   (CUDA IPC, RDMA, …).
+//! - After the handshake the transport calls [`MemRegistry::negotiate`] with the
+//!   peer's [`MemPeerCaps`] to produce a [`NegotiatedMemCaps`].
+//! - Every TX message consults `NegotiatedMemCaps` per [`ZSliceKind`] to decide
+//!   whether to send natively or downgrade (GPU→host staging copy, etc.).
+//!
+//! ## `ext_mem` wire format
+//!
+//! The `ext_mem` bytes (carried inside `ZExtZBuf(0x8)`) are:
+//!
+//! ```text
+//! version     : u8          — always 1
+//! n_backends  : u8
+//! for each backend:
+//!     id      : u8          — MemBackendId discriminant
+//!     len     : u16 (LE)    — byte length of the following caps
+//!     caps    : bytes[len]
+//!
+//! ShmCaps    = { segment_id : u64 (LE) }
+//! CudaIpcCaps = { n_devices : u8 ; device_ids : i32[n_devices] (LE) }
+//! ```
+//!
+//! Unknown `id` values are skipped (forward-compatible).  A length mismatch or
+//! version > 1 causes the entire extension to be ignored (no connection drop).
 //!
 //! # Adding a new backend
 //!
 //! 1. Implement [`ZeroMemTransport`] in a new crate (e.g. `zenoh-rdma`).
-//! 2. Add a `MemBackendId` variant (protocol version bump).
+//! 2. Add a [`MemBackendId`] variant (requires a protocol version bump).
 //! 3. Register with [`MemRegistry::register`] at session startup.
 //! 4. No changes to `map_to_partner`, codec dispatch, or the handshake FSM.
+//!
+//! # Examples
+//!
+//! See the `registry_negotiate` example in the `examples/` directory for a
+//! worked demonstration of registry setup, capability serialization, and
+//! negotiation outcome querying.
 
 pub mod backends;
 pub mod caps;

--- a/commons/zenoh-mem-transport/src/registry.rs
+++ b/commons/zenoh-mem-transport/src/registry.rs
@@ -1,0 +1,94 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! [`MemRegistry`]: runtime registry of zero-copy memory transport backends.
+
+use std::{collections::HashMap, sync::Arc};
+
+use zenoh_buffers::ZSliceKind;
+
+use crate::{
+    caps::{MemBackendCaps, MemPeerCaps, NegotiatedMemCaps},
+    transport::{ArcBackend, ZeroMemTransport},
+};
+
+/// Runtime registry of [`ZeroMemTransport`] backends.
+///
+/// Constructed once at session startup. Shared (via `Arc`) across all transport
+/// connections spawned by the session.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// let mut registry = MemRegistry::new();
+/// registry.register(Arc::new(ShmBackend::new(shm_provider)));
+/// #[cfg(feature = "cuda")]
+/// registry.register(Arc::new(CudaIpcBackend::new()));
+/// let registry = Arc::new(registry);
+/// ```
+#[derive(Default)]
+pub struct MemRegistry {
+    /// Map from ZSliceKind (u8) to the backend that owns it.
+    by_kind: HashMap<u8, ArcBackend>,
+    /// All registered backends in registration order (for capability advertisement).
+    all: Vec<ArcBackend>,
+}
+
+impl MemRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a backend.  Panics if any of its `owned_kinds` is already claimed.
+    pub fn register(&mut self, backend: Arc<dyn ZeroMemTransport>) {
+        for &kind in backend.owned_kinds() {
+            let prev = self.by_kind.insert(kind as u8, backend.clone());
+            assert!(
+                prev.is_none(),
+                "ZSliceKind {} is already registered by another backend",
+                kind as u8
+            );
+        }
+        self.all.push(backend);
+    }
+
+    /// Look up the backend for a given ZSliceKind.
+    pub fn backend_for(&self, kind: ZSliceKind) -> Option<&dyn ZeroMemTransport> {
+        self.by_kind.get(&(kind as u8)).map(|b| b.as_ref())
+    }
+
+    /// Collect all backends' local capability advertisements for `ext_mem`.
+    pub fn local_caps(&self) -> Vec<MemBackendCaps> {
+        self.all.iter().map(|b| b.local_caps()).collect()
+    }
+
+    /// Build a [`NegotiatedMemCaps`] from the peer's advertised capabilities.
+    ///
+    /// Called once per connection after the handshake completes.
+    pub fn negotiate(&self, peer: &MemPeerCaps) -> NegotiatedMemCaps {
+        let mut result = NegotiatedMemCaps::new();
+        for backend in &self.all {
+            let peer_caps = peer.find(backend.backend_id());
+            let outcome = backend.negotiate(peer_caps);
+            for &kind in backend.owned_kinds() {
+                result.set(kind, outcome.clone());
+            }
+        }
+        result
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.all.is_empty()
+    }
+}

--- a/commons/zenoh-mem-transport/src/registry.rs
+++ b/commons/zenoh-mem-transport/src/registry.rs
@@ -92,3 +92,66 @@ impl MemRegistry {
         self.all.is_empty()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use zenoh_buffers::ZSliceKind;
+
+    use super::*;
+    use crate::{
+        backends::shm::ShmBackend,
+        caps::{MemBackendCaps, MemPeerCaps, ShmCaps},
+        DowngradePath, NegotiationResult,
+    };
+
+    fn make_shm_registry() -> MemRegistry {
+        let mut reg = MemRegistry::new();
+        reg.register(ShmBackend::new(42, vec![0]));
+        reg
+    }
+
+    #[test]
+    fn registry_shm_native_when_peer_has_shm() {
+        let reg = make_shm_registry();
+        let peer = MemPeerCaps::new(vec![MemBackendCaps::Shm(ShmCaps { segment_id: 99 })]);
+        let neg = reg.negotiate(&peer);
+        let entry = neg.get(ZSliceKind::ShmPtr).expect("ShmPtr should be negotiated");
+        assert!(matches!(entry.result, NegotiationResult::Native));
+    }
+
+    #[test]
+    fn registry_shm_fallback_to_raw_when_peer_has_no_shm() {
+        let reg = make_shm_registry();
+        let peer = MemPeerCaps::new(vec![]); // peer advertises nothing
+        let neg = reg.negotiate(&peer);
+        let entry = neg.get(ZSliceKind::ShmPtr).expect("ShmPtr should be negotiated");
+        assert!(matches!(
+            entry.result,
+            NegotiationResult::Fallback(DowngradePath::ToRaw)
+        ));
+    }
+
+    #[test]
+    fn registry_local_caps_includes_shm() {
+        let reg = make_shm_registry();
+        let caps = reg.local_caps();
+        assert!(caps.iter().any(|c| matches!(c, MemBackendCaps::Shm(_))));
+    }
+
+    #[test]
+    fn registry_backend_for_unknown_kind_returns_none() {
+        let reg = make_shm_registry();
+        // Raw has no registered backend
+        assert!(reg.backend_for(ZSliceKind::Raw).is_none());
+    }
+
+    #[test]
+    #[should_panic]
+    fn registry_panics_on_duplicate_kind() {
+        let mut reg = MemRegistry::new();
+        reg.register(ShmBackend::new(1, vec![0]));
+        reg.register(ShmBackend::new(2, vec![0])); // second registration of ShmPtr → panic
+    }
+}

--- a/commons/zenoh-mem-transport/src/transport.rs
+++ b/commons/zenoh-mem-transport/src/transport.rs
@@ -1,0 +1,101 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::sync::Arc;
+
+use zenoh_buffers::{ZSlice, ZSliceKind};
+use zenoh_result::ZResult;
+
+use crate::caps::{MemBackendCaps, MemBackendId};
+
+/// Object-safe write interface: write raw bytes into a buffer.
+pub trait HandleWriter: Send {
+    fn write_bytes(&mut self, data: &[u8]) -> ZResult<()>;
+}
+
+/// Object-safe read interface: read raw bytes from a buffer.
+pub trait HandleReader: Send {
+    fn read_bytes(&mut self, buf: &mut [u8]) -> ZResult<()>;
+}
+
+/// How to downgrade a ZSlice when the peer cannot receive it natively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DowngradePath {
+    /// Copy into a SHM region the peer can map (peer supports SHM but not this backend).
+    ToShm,
+    /// Serialize to raw bytes — full CPU copy, peer has no zero-copy support.
+    ToRaw,
+}
+
+/// Outcome of capability negotiation for a single backend/ZSliceKind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NegotiationResult {
+    /// Both peers support this backend natively — send the handle as-is.
+    Native,
+    /// Peer cannot receive this backend. Use the given [`DowngradePath`] on TX.
+    Fallback(DowngradePath),
+    /// Backends are mutually incompatible and no safe fallback is available.
+    /// The ZSlice will be dropped rather than sent.
+    Reject,
+}
+
+/// A pluggable zero-copy memory transport backend.
+///
+/// Implementors: [`ShmBackend`](crate::backends::shm::ShmBackend),
+/// [`CudaIpcBackend`](crate::backends::cuda::CudaIpcBackend).
+///
+/// # Contract
+///
+/// - [`owned_kinds`](ZeroMemTransport::owned_kinds) must return a non-empty slice.
+///   Every `ZSliceKind` must be owned by at most one registered backend.
+/// - [`write_handle`] and [`read_handle`] are called symmetrically: whatever
+///   bytes `write_handle` emits (after the kind byte written by the codec),
+///   `read_handle` must consume exactly.
+/// - [`downgrade`] may block (e.g. `cudaMemcpy`) but must not panic.
+pub trait ZeroMemTransport: Send + Sync + 'static {
+    /// The [`ZSliceKind`] discriminant(s) this backend owns.
+    fn owned_kinds(&self) -> &[ZSliceKind];
+
+    /// The backend identifier used in `ext_mem` capability advertisements.
+    fn backend_id(&self) -> MemBackendId;
+
+    /// Capability data sent in our `InitSyn` / `InitAck`.
+    fn local_caps(&self) -> MemBackendCaps;
+
+    /// Determine whether this backend can be used with the given peer capability.
+    ///
+    /// Called once per transport connection after handshake, per owned kind.
+    fn negotiate(&self, peer: Option<&MemBackendCaps>) -> NegotiationResult;
+
+    /// TX: encode the handle portion of a ZSlice this backend owns.
+    ///
+    /// The kind byte has already been written by the caller; this method writes
+    /// only the backend-specific payload (e.g. IPC handle + len + device_id).
+    fn write_handle(&self, zs: &ZSlice, writer: &mut dyn HandleWriter) -> ZResult<()>;
+
+    /// RX: decode a handle from wire and produce a ZSlice.
+    ///
+    /// `kind` identifies which of `owned_kinds` was on the wire (some backends
+    /// own multiple kinds with different metadata, e.g. `CudaPtr` vs `CudaTensor`).
+    fn read_handle(&self, reader: &mut dyn HandleReader, kind: ZSliceKind) -> ZResult<ZSlice>;
+
+    /// TX fallback: convert a ZSlice owned by this backend to one the peer *can* receive.
+    ///
+    /// Returns `None` if downgrade is impossible (e.g. pure device memory and no
+    /// CUDA runtime available for staging copy).
+    fn downgrade(&self, zs: &ZSlice, path: DowngradePath) -> Option<ZSlice>;
+}
+
+/// Type-erased backend, reference-counted for sharing across the transport.
+pub type ArcBackend = Arc<dyn ZeroMemTransport>;

--- a/commons/zenoh-protocol/src/transport/init.rs
+++ b/commons/zenoh-protocol/src/transport/init.rs
@@ -132,6 +132,8 @@ pub struct InitSyn {
     pub ext_lowlatency: Option<ext::LowLatency>,
     pub ext_compression: Option<ext::Compression>,
     pub ext_patch: ext::PatchType,
+    #[cfg(feature = "cuda")]
+    pub ext_mem: Option<ext::Mem>,
 }
 
 // Extensions
@@ -173,6 +175,11 @@ pub mod ext {
     /// if >= 1, then fragmentation first/drop markers
     pub type Patch = zextz64!(0x7, false);
     pub type PatchType = crate::transport::ext::PatchType<{ Patch::ID }>;
+
+    /// # Mem extension (ID 0x8)
+    /// Advertises zero-copy memory backend capabilities (CUDA IPC, RDMA, etc.)
+    #[cfg(feature = "cuda")]
+    pub type Mem = zextzbuf!(0x8, false);
 }
 
 impl InitSyn {
@@ -199,6 +206,8 @@ impl InitSyn {
         let ext_lowlatency = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
         let ext_compression = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
         let ext_patch = ext::PatchType::rand();
+        #[cfg(feature = "cuda")]
+        let ext_mem = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
 
         Self {
             version,
@@ -215,6 +224,8 @@ impl InitSyn {
             ext_lowlatency,
             ext_compression,
             ext_patch,
+            #[cfg(feature = "cuda")]
+            ext_mem,
         }
     }
 }
@@ -246,6 +257,8 @@ pub struct InitAck {
     pub ext_lowlatency: Option<ext::LowLatency>,
     pub ext_compression: Option<ext::Compression>,
     pub ext_patch: ext::PatchType,
+    #[cfg(feature = "cuda")]
+    pub ext_mem: Option<ext::Mem>,
 }
 
 impl InitAck {
@@ -277,6 +290,8 @@ impl InitAck {
         let ext_lowlatency = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
         let ext_compression = rng.gen_bool(0.5).then_some(ZExtUnit::rand());
         let ext_patch = ext::PatchType::rand();
+        #[cfg(feature = "cuda")]
+        let ext_mem = rng.gen_bool(0.5).then_some(ZExtZBuf::rand());
 
         Self {
             version,
@@ -294,6 +309,8 @@ impl InitAck {
             ext_lowlatency,
             ext_compression,
             ext_patch,
+            #[cfg(feature = "cuda")]
+            ext_mem,
         }
     }
 }

--- a/io/zenoh-transport/Cargo.toml
+++ b/io/zenoh-transport/Cargo.toml
@@ -27,6 +27,7 @@ version = { workspace = true }
 [features]
 auth_pubkey = ["rsa", "transport_auth"]
 auth_usrpwd = ["transport_auth"]
+cuda = ["zenoh-buffers/cuda", "zenoh-codec/cuda", "zenoh-cuda"]
 default = ["test", "transport_multilink"]
 shared-memory = [
   "zenoh-buffers/shared-memory",
@@ -84,6 +85,7 @@ zenoh-link-commons = { workspace = true }
 zenoh-protocol = { workspace = true }
 zenoh-result = { workspace = true }
 zenoh-runtime = { workspace = true }
+zenoh-cuda = { workspace = true, optional = true }
 zenoh-shm = { workspace = true, optional = true }
 zenoh-stats = { workspace = true, optional = true }
 zenoh-sync = { workspace = true }

--- a/io/zenoh-transport/src/manager.rs
+++ b/io/zenoh-transport/src/manager.rs
@@ -129,6 +129,8 @@ pub struct TransportManagerState {
     pub multicast: TransportManagerStateMulticast,
     #[cfg(feature = "shared-memory")]
     pub shm_context: Option<ShmContext>,
+    #[cfg(feature = "cuda")]
+    pub mem_registry: Option<std::sync::Arc<zenoh_mem_transport::MemRegistry>>,
 }
 
 pub struct TransportManagerParams {
@@ -379,6 +381,8 @@ impl TransportManagerBuilder {
             multicast: multicast.state,
             #[cfg(feature = "shared-memory")]
             shm_context,
+            #[cfg(feature = "cuda")]
+            mem_registry: None,
         };
 
         let params = TransportManagerParams { config, state };

--- a/io/zenoh-transport/src/shm.rs
+++ b/io/zenoh-transport/src/shm.rs
@@ -262,6 +262,14 @@ fn map_to_partner<const ID: u8, ShmCfg: PartnerShmConfig>(
     shm_provider: &Option<Arc<LazyShmProvider>>,
 ) {
     for zs in zbuf.zslices_mut() {
+        #[cfg(all(feature = "shared-memory", feature = "cuda"))]
+        if zs.kind == ZSliceKind::CudaPtr {
+            // CUDA IPC: ZSlice already carries a CudaBufInner with an IPC handle.
+            // Signal the sliced codec by setting ext_shm; the codec handles the rest.
+            *ext_shm = Some(ShmType::new());
+            continue;
+        }
+
         match zs.downcast_ref::<ShmBufInner>() {
             None => {
                 if let Some(shm_provider) = shm_provider {

--- a/io/zenoh-transport/src/unicast/establishment/accept.rs
+++ b/io/zenoh-transport/src/unicast/establishment/accept.rs
@@ -87,6 +87,8 @@ struct RecvInitSynOut {
     other_whatami: WhatAmI,
     #[cfg(feature = "shared-memory")]
     ext_shm: Option<AuthSegment>,
+    #[cfg(feature = "cuda")]
+    negotiated_mem: Option<std::sync::Arc<zenoh_mem_transport::NegotiatedMemCaps>>,
 }
 
 // InitAck
@@ -98,11 +100,15 @@ struct SendInitAckIn {
     other_whatami: WhatAmI,
     #[cfg(feature = "shared-memory")]
     ext_shm: Option<AuthSegment>,
+    #[cfg(feature = "cuda")]
+    negotiated_mem: Option<std::sync::Arc<zenoh_mem_transport::NegotiatedMemCaps>>,
 }
 struct SendInitAckOut {
     cookie_nonce: u64,
     #[cfg(feature = "shared-memory")]
     ext_shm: Option<AuthSegment>,
+    #[cfg(feature = "cuda")]
+    negotiated_mem: Option<std::sync::Arc<zenoh_mem_transport::NegotiatedMemCaps>>,
 }
 
 // OpenSyn
@@ -145,6 +151,8 @@ struct AcceptLink<'a> {
     #[cfg(feature = "transport_compression")]
     ext_compression: ext::compression::CompressionFsm<'a>,
     ext_patch: ext::patch::PatchFsm<'a>,
+    #[cfg(feature = "cuda")]
+    ext_mem: Option<ext::mem::MemFsm>,
 }
 
 #[async_trait]
@@ -234,6 +242,11 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
 
         // Extension Shm
+        // Note: capture peer_has_shm before ext_shm is consumed by recv_init_syn.
+        #[cfg(all(feature = "cuda", feature = "shared-memory"))]
+        let peer_has_shm = init_syn.ext_shm.is_some();
+        #[cfg(all(feature = "cuda", not(feature = "shared-memory")))]
+        let peer_has_shm = false;
         #[cfg(feature = "shared-memory")]
         let ext_shm = match &self.ext_shm {
             Some(my_shm) => my_shm
@@ -276,11 +289,22 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
             .await
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
 
+        // Extension Mem (CUDA IPC / zero-copy negotiation)
+        #[cfg(feature = "cuda")]
+        let negotiated_mem = if let Some(mem_fsm) = self.ext_mem.as_ref() {
+            let neg = mem_fsm.negotiate(init_syn.ext_mem, peer_has_shm);
+            Some(std::sync::Arc::new(neg))
+        } else {
+            None
+        };
+
         let output = RecvInitSynOut {
             other_zid: init_syn.zid,
             other_whatami: init_syn.whatami,
             #[cfg(feature = "shared-memory")]
             ext_shm,
+            #[cfg(feature = "cuda")]
+            negotiated_mem,
         };
         Ok(output)
     }
@@ -395,6 +419,10 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
             (encrypted.into(), nonce)
         };
 
+        // Extension Mem — advertise local CUDA caps in the InitAck
+        #[cfg(feature = "cuda")]
+        let ext_mem_ack = self.ext_mem.as_ref().and_then(|f| f.local_ext());
+
         // Send the message on the link
         let msg: TransportMessage = InitAck {
             version: input.mine_version,
@@ -412,6 +440,8 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
             ext_lowlatency,
             ext_compression,
             ext_patch,
+            #[cfg(feature = "cuda")]
+            ext_mem: ext_mem_ack,
         }
         .into();
 
@@ -431,6 +461,8 @@ impl<'a, 'b: 'a> AcceptFsm for &'a mut AcceptLink<'b> {
             cookie_nonce,
             #[cfg(feature = "shared-memory")]
             ext_shm: input.ext_shm,
+            #[cfg(feature = "cuda")]
+            negotiated_mem: input.negotiated_mem,
         };
         Ok(output)
     }
@@ -704,6 +736,12 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
         #[cfg(feature = "transport_compression")]
         ext_compression: ext::compression::CompressionFsm::new(),
         ext_patch: ext::patch::PatchFsm::new(),
+        #[cfg(feature = "cuda")]
+        ext_mem: manager
+            .state
+            .mem_registry
+            .as_ref()
+            .map(|r| ext::mem::MemFsm::new(r.clone())),
     };
 
     // Init handshake
@@ -776,6 +814,8 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
             other_whatami: isyn_out.other_whatami,
             #[cfg(feature = "shared-memory")]
             ext_shm: isyn_out.ext_shm,
+            #[cfg(feature = "cuda")]
+            negotiated_mem: isyn_out.negotiated_mem,
         };
         step!(fsm.send_init_ack((state, iack_in)).await)
     };
@@ -812,6 +852,8 @@ pub(crate) async fn accept_link(link: LinkUnicast, manager: &TransportManager) -
         #[cfg(feature = "auth_usrpwd")]
         auth_id: osyn_out.other_auth_id,
         patch: state.transport.ext_patch.get(),
+        #[cfg(feature = "cuda")]
+        negotiated_mem: iack_out.negotiated_mem,
     };
 
     let a_config = TransportLinkUnicastConfig {

--- a/io/zenoh-transport/src/unicast/establishment/ext/mem.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/mem.rs
@@ -14,9 +14,25 @@
 
 //! FSM for the `ext_mem` handshake extension (CUDA IPC / zero-copy backends).
 //!
-//! Unlike SHM, the mem extension does NOT have a challenge-response phase.
-//! It is purely a capability advertisement: InitSyn carries local caps, InitAck
-//! carries remote caps, and after the handshake we compute [`NegotiatedMemCaps`].
+//! ## Design
+//!
+//! `ext_mem` (extension ID `0x8`) carries a serialised [`MemInitExt`] blob
+//! inside an `InitSyn` / `InitAck` message.  The blob lists the non-SHM
+//! backends (CUDA IPC, RDMA, …) supported by the local peer.
+//!
+//! SHM capability is conveyed separately by the existing `ext_shm` (ID `0x2`)
+//! challenge-response mechanism.  [`MemFsm::negotiate`] synthesises a unified
+//! [`NegotiatedMemCaps`] by combining both sources:
+//!
+//! | peer signal         | ShmPtr result           | CudaPtr result                   |
+//! |---------------------|-------------------------|----------------------------------|
+//! | `ext_shm` present   | `Native`                | —                                |
+//! | `ext_shm` absent    | `Fallback(ToRaw)`       | —                                |
+//! | `ext_mem` CudaIpc   | —                       | `Native` (same-host) or fallback |
+//! | `ext_mem` absent    | —                       | `Fallback(ToRaw)`                |
+//!
+//! Unlike `ext_shm`, there is **no Open-phase** for `ext_mem`.  The negotiation
+//! result is available immediately after `InitAck` is processed.
 
 use std::sync::Arc;
 

--- a/io/zenoh-transport/src/unicast/establishment/ext/mem.rs
+++ b/io/zenoh-transport/src/unicast/establishment/ext/mem.rs
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2023 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+//! FSM for the `ext_mem` handshake extension (CUDA IPC / zero-copy backends).
+//!
+//! Unlike SHM, the mem extension does NOT have a challenge-response phase.
+//! It is purely a capability advertisement: InitSyn carries local caps, InitAck
+//! carries remote caps, and after the handshake we compute [`NegotiatedMemCaps`].
+
+use std::sync::Arc;
+
+use zenoh_buffers::{reader::HasReader, ZBuf};
+use zenoh_mem_transport::{
+    caps::ShmCaps, MemBackendCaps, MemInitExt, MemPeerCaps, MemRegistry, NegotiatedMemCaps,
+};
+use zenoh_protocol::transport::init;
+
+/// The mem extension FSM — used by both the accepting and opening sides.
+pub(crate) struct MemFsm {
+    registry: Arc<MemRegistry>,
+}
+
+impl MemFsm {
+    pub(crate) fn new(registry: Arc<MemRegistry>) -> Self {
+        Self { registry }
+    }
+
+    /// Serialise local capabilities into `ext_mem` for an outgoing InitSyn or InitAck.
+    pub(crate) fn local_ext(&self) -> Option<init::ext::Mem> {
+        let caps = self.registry.local_caps();
+        // Only include non-SHM backends in ext_mem (SHM auth is in ext_shm).
+        let cuda_caps: Vec<_> = caps
+            .into_iter()
+            .filter(|c| !matches!(c, MemBackendCaps::Shm(_)))
+            .collect();
+        if cuda_caps.is_empty() {
+            return None;
+        }
+        let ext = MemInitExt::new(cuda_caps);
+        let bytes: Vec<u8> = ext.to_bytes();
+        let zbuf = ZBuf::from(bytes);
+        Some(init::ext::Mem::new(zbuf))
+    }
+
+    /// Build [`NegotiatedMemCaps`] from:
+    /// - `peer_ext_mem`: the remote peer's ext_mem (CUDA / other caps)
+    /// - `peer_has_shm`: whether the peer sent ext_shm (meaning SHM is available)
+    pub(crate) fn negotiate(
+        &self,
+        peer_ext_mem: Option<init::ext::Mem>,
+        peer_has_shm: bool,
+    ) -> NegotiatedMemCaps {
+        let mut peer_backends: Vec<MemBackendCaps> = Vec::new();
+
+        // If peer sent ext_shm, they have SHM capability.
+        if peer_has_shm {
+            peer_backends.push(MemBackendCaps::Shm(ShmCaps { segment_id: 0 }));
+        }
+
+        // Parse ext_mem for CUDA / other caps.
+        if let Some(mem_ext) = peer_ext_mem {
+            // Collect ZBuf into a contiguous byte vec for parsing.
+            let mut reader = mem_ext.value.reader();
+            let mut bytes: Vec<u8> = Vec::new();
+            use zenoh_buffers::reader::Reader;
+            while reader.can_read() {
+                if let Ok(b) = reader.read_u8() {
+                    bytes.push(b);
+                } else {
+                    break;
+                }
+            }
+            if let Some(parsed) = MemInitExt::from_bytes(&bytes) {
+                peer_backends.extend(parsed.backends);
+            }
+        }
+
+        let peer_caps = MemPeerCaps::new(peer_backends);
+        self.registry.negotiate(&peer_caps)
+    }
+}

--- a/io/zenoh-transport/src/unicast/establishment/open.rs
+++ b/io/zenoh-transport/src/unicast/establishment/open.rs
@@ -89,6 +89,8 @@ struct RecvInitAckOut {
     other_cookie: ZSlice,
     #[cfg(feature = "shared-memory")]
     ext_shm: Option<AuthSegment>,
+    #[cfg(feature = "cuda")]
+    negotiated_mem: Option<std::sync::Arc<zenoh_mem_transport::NegotiatedMemCaps>>,
 }
 
 // OpenSyn
@@ -126,6 +128,8 @@ struct OpenLink<'a> {
     #[cfg(feature = "transport_compression")]
     ext_compression: ext::compression::CompressionFsm<'a>,
     ext_patch: ext::patch::PatchFsm<'a>,
+    #[cfg(feature = "cuda")]
+    ext_mem: Option<ext::mem::MemFsm>,
 }
 
 #[async_trait]
@@ -201,6 +205,10 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
             .await
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
 
+        // Extension Mem — advertise local CUDA caps in the InitSyn
+        #[cfg(feature = "cuda")]
+        let ext_mem_syn = self.ext_mem.as_ref().and_then(|f| f.local_ext());
+
         let msg: TransportMessage = InitSyn {
             version: input.mine_version,
             whatami: input.mine_whatami,
@@ -216,6 +224,8 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
             ext_lowlatency,
             ext_compression,
             ext_patch,
+            #[cfg(feature = "cuda")]
+            ext_mem: ext_mem_syn,
         }
         .into();
 
@@ -321,6 +331,11 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
 
         // Extension Shm
+        // Note: capture peer_has_shm before ext_shm is consumed by recv_init_ack.
+        #[cfg(all(feature = "cuda", feature = "shared-memory"))]
+        let peer_has_shm = init_ack.ext_shm.is_some();
+        #[cfg(all(feature = "cuda", not(feature = "shared-memory")))]
+        let peer_has_shm = false;
         #[cfg(feature = "shared-memory")]
         let shm_segment = match self.ext_shm.as_ref() {
             Some(ext) => ext
@@ -363,12 +378,23 @@ impl<'a, 'b: 'a> OpenFsm for &'a mut OpenLink<'b> {
             .await
             .map_err(|e| (e, Some(close::reason::GENERIC)))?;
 
+        // Extension Mem — negotiate CUDA caps from peer's InitAck
+        #[cfg(feature = "cuda")]
+        let negotiated_mem = if let Some(mem_fsm) = self.ext_mem.as_ref() {
+            let neg = mem_fsm.negotiate(init_ack.ext_mem, peer_has_shm);
+            Some(std::sync::Arc::new(neg))
+        } else {
+            None
+        };
+
         let output = RecvInitAckOut {
             other_zid: init_ack.zid,
             other_whatami: init_ack.whatami,
             other_cookie: init_ack.cookie,
             #[cfg(feature = "shared-memory")]
             ext_shm: shm_segment,
+            #[cfg(feature = "cuda")]
+            negotiated_mem,
         };
         Ok(output)
     }
@@ -591,6 +617,12 @@ pub(crate) async fn open_link(
         #[cfg(feature = "transport_compression")]
         ext_compression: ext::compression::CompressionFsm::new(),
         ext_patch: ext::patch::PatchFsm::new(),
+        #[cfg(feature = "cuda")]
+        ext_mem: manager
+            .state
+            .mem_registry
+            .as_ref()
+            .map(|r| ext::mem::MemFsm::new(r.clone())),
     };
 
     // Clippy raises a warning because `batch_size::UNICAST` is currently equal to `BatchSize::MAX`.
@@ -689,6 +721,8 @@ pub(crate) async fn open_link(
         #[cfg(feature = "auth_usrpwd")]
         auth_id: UsrPwdId(None),
         patch: state.transport.ext_patch.get(),
+        #[cfg(feature = "cuda")]
+        negotiated_mem: iack_out.negotiated_mem,
     };
 
     let o_config = TransportLinkUnicastConfig {

--- a/io/zenoh-transport/src/unicast/mod.rs
+++ b/io/zenoh-transport/src/unicast/mod.rs
@@ -64,6 +64,8 @@ pub(crate) struct TransportConfigUnicast {
     #[cfg(feature = "auth_usrpwd")]
     pub(crate) auth_id: UsrPwdId,
     pub(crate) patch: PatchType,
+    #[cfg(feature = "cuda")]
+    pub(crate) negotiated_mem: Option<std::sync::Arc<zenoh_mem_transport::NegotiatedMemCaps>>,
 }
 
 /// [`TransportUnicast`] is the transport handler returned

--- a/zenoh/Cargo.toml
+++ b/zenoh/Cargo.toml
@@ -52,6 +52,12 @@ internal = [
 internal_config = []
 plugins = []
 runtime_plugins = ["plugins"]
+cuda = [
+  "zenoh-buffers/cuda",
+  "zenoh-codec/cuda",
+  "zenoh-cuda",
+  "zenoh-transport/cuda",
+]
 shared-memory = [
   "zenoh-buffers/shared-memory",
   "zenoh-protocol/shared-memory",
@@ -121,6 +127,7 @@ zenoh-plugin-trait = { workspace = true }
 zenoh-protocol = { workspace = true, features = ["std"] }
 zenoh-result = { workspace = true }
 zenoh-runtime = { workspace = true }
+zenoh-cuda = { workspace = true, optional = true }
 zenoh-shm = { workspace = true, optional = true }
 zenoh-stats = { workspace = true, optional = true }
 zenoh-sync = { workspace = true }


### PR DESCRIPTION
## Summary

- Adds `ZSliceKind::CudaPtr` (0x2) and `ZSliceKind::CudaTensor` (0x3) to `zenoh-buffers`, enabling GPU memory to travel as a Zenoh payload via CUDA IPC handles (77 bytes on wire, zero CPU copies of tensor data)
- Introduces `zenoh-cuda` crate: `CudaBuf` for owning/borrowed device allocations, IPC handle serialization, `copy_to_host`, DLPack `TensorMeta` for typed N-D tensors
- Extends `zenoh-mem-transport` with a CUDA backend and `ext_mem` (0x8) capability flag for transport negotiation
- Fixes `cudaIpcOpenMemHandle` FFI (pass handle by value, not pointer), `cudaMalloc`-only IPC constraint, and zero-length push path

## Key Changes

- `commons/zenoh-buffers`: `ZSliceKind` variants, `ZBuf::typed_cuda_slices()` iterator
- `commons/zenoh-cuda`: new crate — `CudaBuf`, `TensorMeta`, IPC handle codec
- `commons/zenoh-mem-transport`: CUDA backend, capability negotiation, registry integration
- `io/zenoh-transport`: SHM path passes CUDA slices through without converting to POSIX SHM
- 16 unit tests + `registry_negotiate` example

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

**No specific label requirements detected.**

Current labels: _No labels_

Add one of these labels to this PR to see relevant checklist items: `api-sync`, `breaking-change`, `bug`, `ci`, `dependencies`, `documentation`, `enhancement`, `new feature`, `internal`

*This section updates automatically when labels change.*

<!-- 🏷️ Label-Based Checklist END -->