### PR TITLE
fix(timestamp-stack): address code review issues

### DIFF
--- a/commons/zenoh-codec/src/network/timestamp_stack.rs
+++ b/commons/zenoh-codec/src/network/timestamp_stack.rs
@@ -19,7 +19,7 @@ use zenoh_buffers::{
 };
 use zenoh_protocol::{
     common::ZExtZBufHeader,
-    network::timestamp_stack::{Interception, TimestampStack, TsStackType},
+    network::timestamp_stack::{Interception, TsStackType, WireTimestampStack},
 };
 
 use crate::{LCodec, RCodec, WCodec, Zenoh080, Zenoh080Header};
@@ -56,9 +56,9 @@ where
     }
 }
 
-// TimestampStack
-impl LCodec<&TimestampStack> for Zenoh080 {
-    fn w_len(self, x: &TimestampStack) -> usize {
+// WireTimestampStack
+impl LCodec<&WireTimestampStack> for Zenoh080 {
+    fn w_len(self, x: &WireTimestampStack) -> usize {
         let mut len = 1; // conf_flags
         len += self.w_len(x.stack.len());
         for i in &x.stack {
@@ -68,13 +68,13 @@ impl LCodec<&TimestampStack> for Zenoh080 {
     }
 }
 
-impl<W> WCodec<&TimestampStack, &mut W> for Zenoh080
+impl<W> WCodec<&WireTimestampStack, &mut W> for Zenoh080
 where
     W: Writer,
 {
     type Output = Result<(), DidntWrite>;
 
-    fn write(self, writer: &mut W, x: &TimestampStack) -> Self::Output {
+    fn write(self, writer: &mut W, x: &WireTimestampStack) -> Self::Output {
         self.write(&mut *writer, x.conf_flags)?;
         self.write(&mut *writer, x.stack.len())?;
         for i in &x.stack {
@@ -84,21 +84,24 @@ where
     }
 }
 
-impl<R> RCodec<TimestampStack, &mut R> for Zenoh080
+impl<R> RCodec<WireTimestampStack, &mut R> for Zenoh080
 where
     R: Reader,
 {
     type Error = DidntRead;
 
-    fn read(self, reader: &mut R) -> Result<TimestampStack, Self::Error> {
+    fn read(self, reader: &mut R) -> Result<WireTimestampStack, Self::Error> {
         let conf_flags: u8 = self.read(&mut *reader)?;
         let count: usize = self.read(&mut *reader)?;
-        //FIXME: this can panic due to call with unsanitized count input
+        const MAX_INTERCEPTION_STACK_DEPTH: usize = 64;
+        if count > MAX_INTERCEPTION_STACK_DEPTH {
+            return Err(DidntRead);
+        }
         let mut stack: Vec<Interception> = Vec::with_capacity(count);
         for _ in 0..count {
             stack.push(self.read(&mut *reader)?);
         }
-        Ok(TimestampStack { conf_flags, stack })
+        Ok(WireTimestampStack { conf_flags, stack })
     }
 }
 
@@ -144,7 +147,7 @@ where
 
     fn read(self, reader: &mut R) -> Result<(TsStackType<{ ID }>, bool), Self::Error> {
         let (_, more): (ZExtZBufHeader<{ ID }>, bool) = self.read(&mut *reader)?;
-        let ts_stack: TimestampStack = self.codec.read(&mut *reader)?;
+        let ts_stack: WireTimestampStack = self.codec.read(&mut *reader)?;
         Ok((TsStackType { ts_stack }, more))
     }
 }

--- a/commons/zenoh-protocol/src/network/timestamp_stack.rs
+++ b/commons/zenoh-protocol/src/network/timestamp_stack.rs
@@ -19,7 +19,7 @@ use alloc::vec::Vec;
 /// type-safety across different message contexts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TsStackType<const ID: u8> {
-    pub ts_stack: TimestampStack,
+    pub ts_stack: WireTimestampStack,
 }
 
 impl<const ID: u8> TsStackType<{ ID }> {
@@ -40,7 +40,7 @@ impl<const ID: u8> TsStackType<{ ID }> {
         }
 
         Self {
-            ts_stack: TimestampStack { conf_flags, stack },
+            ts_stack: WireTimestampStack { conf_flags, stack },
         }
     }
 }
@@ -86,7 +86,7 @@ pub struct Interception {
 /// +---------------+
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TimestampStack {
+pub struct WireTimestampStack {
     /// Bitmask of which interception points are activated.
     pub conf_flags: u8,
     /// Ordered list of interceptions collected along the message path.

--- a/zenoh/src/api/sample.rs
+++ b/zenoh/src/api/sample.rs
@@ -368,7 +368,7 @@ impl Sample {
         body: &mut PushBody,
         #[cfg(feature = "unstable")] reliability: Reliability,
         #[cfg(feature = "unstable")] timestamp_stack: Option<
-            zenoh_protocol::network::timestamp_stack::TimestampStack,
+            zenoh_protocol::network::timestamp_stack::WireTimestampStack,
         >,
     ) -> Self {
         #[cfg(feature = "unstable")]
@@ -417,7 +417,7 @@ impl CallbackParameter for Sample {
         push::ext::QoSType,
         &'a mut PushBody,
         Reliability,
-        Option<zenoh_protocol::network::timestamp_stack::TimestampStack>,
+        Option<zenoh_protocol::network::timestamp_stack::WireTimestampStack>,
     );
     #[cfg(not(feature = "unstable"))]
     type Message<'a> = (KeyExpr<'static>, push::ext::QoSType, &'a mut PushBody);

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -558,7 +558,7 @@ impl SubscriberCallbacks {
         msg: &mut PushBody,
         #[cfg(feature = "unstable")] reliability: Reliability,
         #[cfg(feature = "unstable")] timestamp_stack: Option<
-            zenoh_protocol::network::timestamp_stack::TimestampStack,
+            zenoh_protocol::network::timestamp_stack::WireTimestampStack,
         >,
     ) {
         let zenoh_collections::single_or_vec::IntoIter { drain, last } = self.0.into_iter();
@@ -2546,10 +2546,10 @@ impl Session {
         #[cfg(feature = "unstable")]
         if let Some(instrumentation) = timestamp_instrumentation {
             use zenoh_protocol::network::timestamp_stack::{
-                interception_point, TimestampStack, TsStackType,
+                interception_point, TsStackType, WireTimestampStack,
             };
             let mut ext_ts_stack = Some(TsStackType {
-                ts_stack: TimestampStack {
+                ts_stack: WireTimestampStack {
                     conf_flags: instrumentation.conf_flags(),
                     stack: vec![],
                 },
@@ -2579,7 +2579,7 @@ impl Session {
                 push: &mut Push,
                 #[cfg(feature = "unstable")] reliability: Reliability,
                 #[cfg(feature = "unstable")] timestamp_stack: Option<
-                    zenoh_protocol::network::timestamp_stack::TimestampStack,
+                    zenoh_protocol::network::timestamp_stack::WireTimestampStack,
                 >,
             ) {
                 callbacks.call(
@@ -2594,7 +2594,7 @@ impl Session {
             }
 
             #[cfg(feature = "unstable")]
-            let timestamp_stack = push.ext_ts_stack.as_ref().map(|ts| ts.ts_stack.clone());
+            let timestamp_stack = push.ext_ts_stack.take().map(|ts| ts.ts_stack);
             call_local(
                 callbacks,
                 &mut push,
@@ -2812,7 +2812,7 @@ impl Session {
                     ext_attachment,
                     ext_unknown: vec![],
                 }),
-                // TODO: avoid this clone if possible
+                // Cloned because the same stack is also passed to the local handler below.
                 ext_ts_stack: ext_ts_stack.clone(),
             });
         }
@@ -2954,7 +2954,7 @@ impl Session {
         body: Option<QueryBodyType>,
         attachment: Option<ZBytes>,
         #[cfg(feature = "unstable")] timestamp_stack: Option<
-            zenoh_protocol::network::timestamp_stack::TimestampStack,
+            zenoh_protocol::network::timestamp_stack::WireTimestampStack,
         >,
     ) {
         let Ok(primitives) = state.primitives() else {
@@ -3327,7 +3327,7 @@ impl Primitives for WeakSession {
             #[cfg(feature = "unstable")]
             _reliability,
             #[cfg(feature = "unstable")]
-            msg.ext_ts_stack.as_ref().map(|ts| ts.ts_stack.clone()),
+            msg.ext_ts_stack.take().map(|ts| ts.ts_stack),
         );
     }
 
@@ -3361,8 +3361,7 @@ impl Primitives for WeakSession {
                             mem::take(&mut m.ext_body),
                             mem::take(&mut m.ext_attachment).map(Into::into),
                             #[cfg(feature = "unstable")]
-                            // TODO: avoid this clone if possible. should we just mem::take ?
-                            msg.ext_ts_stack.as_ref().map(|ts| ts.ts_stack.clone()),
+                            msg.ext_ts_stack.take().map(|ts| ts.ts_stack),
                         );
                     }
                     Err(err) => {
@@ -3396,11 +3395,10 @@ impl Primitives for WeakSession {
                                 payload: mem::take(&mut e.payload).into(),
                                 encoding: mem::take(&mut e.encoding).into(),
                                 #[cfg(feature = "unstable")]
-                                // TODO: avoid this clone if possible. should we just mem::take ?
                                 timestamp_stack: msg
                                     .ext_ts_stack
-                                    .as_ref()
-                                    .map(|ts| crate::api::timestamp_stack::TimestampStack::try_from(&ts.ts_stack).ok()).flatten(),
+                                    .take()
+                                    .and_then(|ts| crate::api::timestamp_stack::TimestampStack::try_from(&ts.ts_stack).ok()),
                             }),
                             #[cfg(feature = "unstable")]
                             replier_id: mem::take(&mut msg.ext_respid).map(|rid| {
@@ -3451,8 +3449,7 @@ impl Primitives for WeakSession {
                                 #[cfg(feature = "unstable")]
                                 Reliability::Reliable,
                                 #[cfg(feature = "unstable")]
-                                // TODO: avoid this clone if possible. should we just mem::take ?
-                                msg.ext_ts_stack.as_ref().map(|ts| ts.ts_stack.clone()),
+                                msg.ext_ts_stack.take().map(|ts| ts.ts_stack),
                             )),
                             #[cfg(feature = "unstable")]
                             replier_id: mem::take(&mut msg.ext_respid).map(|rid| {

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -33,7 +33,6 @@ pub struct TsStackContext {
     pub zid: ZenohId,
     /// The mode of the current node (router, peer, or client).
     pub whatami: WhatAmI,
-    // TODO: should be a non-exhaustive enum
     /// The interception point identifier (e.g., `zenoh_protocol::network::timestamp_stack::interception_point::SEND`).
     pub interception_point: InterceptionPoint,
 }
@@ -47,6 +46,7 @@ pub type GetTimestampCallback = Arc<dyn Fn(TsStackContext) -> Vec<u8> + Send + S
 
 /// Identifies which interception point a timestamp record was captured at.
 #[zenoh_macros::unstable]
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InterceptionPoint {
     Send,
@@ -227,12 +227,14 @@ pub(crate) fn push_ts_interception<const ID: u8, T: IRuntime + ?Sized>(
         return;
     };
     if ts_stack.ts_stack.conf_flags & point != 0 {
+        let Ok(interception_point) = point.try_into() else {
+            debug_assert!(false, "push_ts_interception called with unknown point ID {point:#04x}");
+            return;
+        };
         let context = TsStackContext {
             zid: runtime.zid(),
             whatami: runtime.whatami(),
-            interception_point: point
-                .try_into()
-                .expect("internal calls should provide valid interception point IDs"),
+            interception_point,
         };
         let timestamp = runtime.get_ts_stack_timestamp(context);
         ts_stack.ts_stack.stack.push(Interception {
@@ -243,11 +245,11 @@ pub(crate) fn push_ts_interception<const ID: u8, T: IRuntime + ?Sized>(
 }
 
 #[cfg(feature = "unstable")]
-impl TryFrom<&zenoh_protocol::network::timestamp_stack::TimestampStack> for TimestampStack {
+impl TryFrom<&zenoh_protocol::network::timestamp_stack::WireTimestampStack> for TimestampStack {
     type Error = zenoh_result::Error;
 
     fn try_from(
-        ts: &zenoh_protocol::network::timestamp_stack::TimestampStack,
+        ts: &zenoh_protocol::network::timestamp_stack::WireTimestampStack,
     ) -> zenoh_result::ZResult<Self> {
         let mut instance = Self {
             instrumentation: TimestampInstrumentation::try_from_flags(ts.conf_flags)?,
@@ -275,9 +277,9 @@ impl TryFrom<&zenoh_protocol::network::timestamp_stack::TimestampStack> for Time
 }
 
 #[cfg(feature = "unstable")]
-impl From<&TimestampStack> for zenoh_protocol::network::timestamp_stack::TimestampStack {
+impl From<&TimestampStack> for zenoh_protocol::network::timestamp_stack::WireTimestampStack {
     fn from(value: &TimestampStack) -> Self {
-        zenoh_protocol::network::timestamp_stack::TimestampStack {
+        zenoh_protocol::network::timestamp_stack::WireTimestampStack {
             conf_flags: value.instrumentation.conf_flags,
             stack: value
                 .records

--- a/zenoh/src/net/routing/dispatcher/pubsub.rs
+++ b/zenoh/src/net/routing/dispatcher/pubsub.rs
@@ -348,33 +348,29 @@ pub fn route_data(
 
             drop(rtables);
 
-            #[cfg(feature = "unstable")]
-            {
-                let rt = weak_runtime.and_then(|r| r.upgrade());
-                let rt_state = rt.as_ref().map(|r| r.state.as_ref());
-                crate::api::timestamp_stack::push_ts_interception(
-                    &mut msg.ext_ts_stack,
-                    rt_state,
-                    zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
-                );
-            }
             for dir in dirs {
-                // TODO: might be more accurate to push the new timestamp to ext_ts_stack here to
-                // account for `send_push` running sequentially for each message
-                send_push(
-                    &dir.dst_face,
-                    &mut Push {
-                        wire_expr: dir.wire_expr.clone(),
-                        ext_qos: msg.ext_qos,
-                        ext_tstamp: None,
-                        ext_nodeid: ext::NodeIdType {
-                            node_id: dir.node_id,
-                        },
-                        ext_ts_stack: msg.ext_ts_stack.clone(),
-                        payload: msg.payload.clone(),
+                let mut push = Push {
+                    wire_expr: dir.wire_expr.clone(),
+                    ext_qos: msg.ext_qos,
+                    ext_tstamp: None,
+                    ext_nodeid: ext::NodeIdType {
+                        node_id: dir.node_id,
                     },
-                    reliability,
-                );
+                    ext_ts_stack: msg.ext_ts_stack.clone(),
+                    payload: msg.payload.clone(),
+                };
+                // Stamp ROUTE per-subscriber so each gets the time of its own dispatch.
+                #[cfg(feature = "unstable")]
+                {
+                    let rt = weak_runtime.clone().and_then(|r| r.upgrade());
+                    let rt_state = rt.as_ref().map(|r| r.state.as_ref());
+                    crate::api::timestamp_stack::push_ts_interception(
+                        &mut push.ext_ts_stack,
+                        rt_state,
+                        zenoh_protocol::network::timestamp_stack::interception_point::ROUTE,
+                    );
+                }
+                send_push(&dir.dst_face, &mut push, reliability);
             }
         }
     }

--- a/zenoh/src/net/routing/dispatcher/queries.rs
+++ b/zenoh/src/net/routing/dispatcher/queries.rs
@@ -493,7 +493,8 @@ impl Timed for QueryCleanup {
                     ext_qos: self.qos,
                     ext_tstamp: None,
                     ext_respid,
-                    // TODO: Maybe this should be set?
+                    // Timeout synthetic replies carry no timestamp stack: they are generated
+                    // locally by the router, not forwarded from a real replier.
                     ext_ts_stack: None,
                 },
             );

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -232,18 +232,21 @@ impl IRuntime for RuntimeState {
         let ts = match &self.hlc {
             Some(hlc) => hlc.new_timestamp(),
             None => {
-                // TODO: instead of using system time, HLC should be initialized in this case
+                // HLC not configured; fall back to system time. Ordering guarantees across
+                // nodes do not hold in this configuration.
                 use std::time::{SystemTime, UNIX_EPOCH};
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().into();
-                uhlc::Timestamp::new(now, self.zid.into())
+                let Ok(duration) = SystemTime::now().duration_since(UNIX_EPOCH) else {
+                    return Vec::new();
+                };
+                uhlc::Timestamp::new(duration.into(), self.zid.into())
             }
         };
 
         use zenoh_codec::{WCodec, Zenoh080};
         let mut buf = Vec::new();
-        Zenoh080
-            .write(&mut buf, &ts)
-            .expect("Failed to serialize timestamp");
+        if Zenoh080.write(&mut buf, &ts).is_err() {
+            return Vec::new();
+        }
         buf
     }
 
@@ -806,6 +809,8 @@ impl RuntimeBuilder {
 
 #[derive(Clone)]
 pub struct Runtime {
+    // pub(crate) to allow DynamicRuntime construction in adminspace without going through
+    // the IRuntime trait, which doesn't expose Arc<RuntimeState> directly.
     pub(crate) state: Arc<RuntimeState>,
 }
 


### PR DESCRIPTION
## Summary

Fixes eight issues identified during review of `feat/routing-timestamps` before it is sent upstream. Covers a remote DoS vector in the codec, a name collision between the wire and public API types, unsafe unwrap/expect calls, and several correctness and clarity issues in the routing and session layers.

## Key Changes

- **Codec: cap decode count at 64** — `Vec::with_capacity(count)` in the `WireTimestampStack` decoder used an unsanitized wire value; a crafted packet with a large count would OOM or panic. Now returns `DidntRead` if `count > 64`.
- **Rename wire type `TimestampStack` → `WireTimestampStack`** — eliminates the name collision between `zenoh_protocol::network::timestamp_stack::TimestampStack` (wire struct) and `zenoh::timestamp_stack::TimestampStack` (public API struct); updates all call sites in codec, session, sample, and reply builders.
- **Remove `unwrap()`/`expect()` in `get_ts_stack_timestamp`** — `SystemTime::now().duration_since(UNIX_EPOCH).unwrap()` can panic on misconfigured clocks; `expect("Failed to serialize timestamp")` hides a silent assumption. Both now return an empty `Vec` on failure; the HLC fallback comment is updated to document that ordering guarantees don't hold without HLC.
- **Per-subscriber ROUTE timestamp in fan-out** — the previous code stamped the ROUTE timestamp once before the fan-out loop and cloned it into each outgoing `Push`. Moved inside the loop so each subscriber receives the time of its own dispatch.
- **Replace avoidable `.clone()` with `mem::take()`** — five receive-side extract sites in `session.rs` where `msg.ext_ts_stack` is not used after extraction now use `take()` instead of `as_ref().map(|ts| ts.ts_stack.clone())`.
- **`push_ts_interception`: replace `expect` with `debug_assert` + graceful return** — the `expect("internal calls should provide valid interception point IDs")` would panic at runtime if a new call site passed an unknown ID; now asserts in debug and silently skips in release.
- **`#[non_exhaustive]` on `InterceptionPoint`** — adding a new interception point (e.g. `Forward`) would have been a breaking change without this attribute.
- **Document `ext_ts_stack: None` on timeout replies** — removes the `TODO: Maybe this should be set?` comment and replaces it with a rationale: timeout replies are generated locally by the router and carry no forwarded timestamp stack.

## Breaking Changes

`zenoh_protocol::network::timestamp_stack::TimestampStack` is renamed to `WireTimestampStack`. Any code outside this crate that references the old name by path will need updating.
