### PR TITLE
feat(timestamp-stack): add routing timestamp instrumentation

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -177,3 +177,18 @@ required-features = ["shared-memory", "unstable"]
 name = "z_posix_shm_provider"
 path = "examples/z_posix_shm_provider.rs"
 required-features = ["shared-memory", "unstable"]
+
+[[example]]
+name = "z_timestamp_instrumentation"
+path = "examples/z_timestamp_instrumentation.rs"
+required-features = ["unstable"]
+
+[[example]]
+name = "z_latency_collector"
+path = "examples/z_latency_collector.rs"
+required-features = ["unstable"]
+
+[[example]]
+name = "z_proprietary_token"
+path = "examples/z_proprietary_token.rs"
+required-features = ["unstable"]

--- a/examples/examples/z_latency_collector.rs
+++ b/examples/examples/z_latency_collector.rs
@@ -28,7 +28,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use zenoh::timestamp_stack::{InstrumentationTimestamp, InterceptionPoint, TimestampInstrumentation};
+use zenoh::timestamp_stack::{InstrumentationTimestamp, InterceptionPoint, TimestampInstrumentationBuilder};
 use zenoh::Config;
 
 const N_SAMPLES: usize = 500;
@@ -121,7 +121,12 @@ async fn main() {
     );
 
     let session = zenoh::open(Config::default()).await.unwrap();
-    let instr = TimestampInstrumentation::new(true, true, true).unwrap();
+    let instr = TimestampInstrumentationBuilder::new()
+        .set_send(true)
+        .set_route(true)
+        .set_receive(true)
+        .build()
+        .unwrap();
 
     let acc: Arc<Mutex<HopAccumulator>> = Arc::new(Mutex::new(HopAccumulator::default()));
     let acc2 = acc.clone();

--- a/examples/examples/z_latency_collector.rs
+++ b/examples/examples/z_latency_collector.rs
@@ -1,0 +1,154 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+//! Demonstrates per-hop latency profiling using `TsStack`.
+//!
+//! Publishes [`N_SAMPLES`] messages with Send+Route+Receive instrumentation,
+//! collects `TsStack` records in a subscriber, and prints p50/p95/p99 latency
+//! for each hop (Send→Receive, Send→Route, Route→Receive).
+//!
+//! Route timestamps only appear when messages pass through a Zenoh router.
+//! In the default loopback configuration only Send→Receive is populated.
+//!
+//! Run with:
+//! ```
+//! cargo run --example z_latency_collector --features unstable
+//! ```
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use zenoh::timestamp_stack::{InstrumentationTimestamp, InterceptionPoint, TimestampInstrumentation};
+use zenoh::Config;
+
+const N_SAMPLES: usize = 500;
+
+// NTP64 layout: upper 32 bits = seconds since epoch, lower 32 bits = sub-second fraction.
+fn ntp_to_ns(ntp: u64) -> u64 {
+    let secs = ntp >> 32;
+    let frac = ntp & 0xFFFF_FFFF;
+    secs.saturating_mul(1_000_000_000) + ((frac * 1_000_000_000) >> 32)
+}
+
+fn percentile(sorted: &[i64], p: f64) -> i64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = ((sorted.len() as f64 - 1.0) * p / 100.0).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+#[derive(Default)]
+struct HopAccumulator {
+    send_receive: Vec<i64>,
+    send_route: Vec<i64>,
+    route_receive: Vec<i64>,
+}
+
+impl HopAccumulator {
+    fn ingest(&mut self, stack: &zenoh::timestamp_stack::TimestampStack) {
+        let mut send_ns: Option<u64> = None;
+        let mut route_ns: Option<u64> = None;
+        let mut receive_ns: Option<u64> = None;
+
+        for rec in stack.records() {
+            let InstrumentationTimestamp::UHLC(ts) = rec.timestamp() else {
+                continue;
+            };
+            let ns = ntp_to_ns(ts.get_time().as_u64());
+            match rec.point() {
+                InterceptionPoint::Send => send_ns = Some(ns),
+                InterceptionPoint::Route => route_ns = Some(ns),
+                InterceptionPoint::Receive => receive_ns = Some(ns),
+                _ => {}
+            }
+        }
+
+        if let (Some(s), Some(r)) = (send_ns, receive_ns) {
+            self.send_receive.push(r as i64 - s as i64);
+        }
+        if let (Some(s), Some(r)) = (send_ns, route_ns) {
+            self.send_route.push(r as i64 - s as i64);
+        }
+        if let (Some(r), Some(rcv)) = (route_ns, receive_ns) {
+            self.route_receive.push(rcv as i64 - r as i64);
+        }
+    }
+
+    fn print_hop(label: &str, data: &[i64]) {
+        if data.is_empty() {
+            return;
+        }
+        let mut sorted = data.to_vec();
+        sorted.sort_unstable();
+        println!(
+            "  {:<22}  p50={:>7} µs   p95={:>7} µs   p99={:>7} µs   n={}",
+            label,
+            percentile(&sorted, 50.0) / 1_000,
+            percentile(&sorted, 95.0) / 1_000,
+            percentile(&sorted, 99.0) / 1_000,
+            sorted.len(),
+        );
+    }
+
+    fn print_stats(&self) {
+        Self::print_hop("Send → Receive", &self.send_receive);
+        Self::print_hop("Send → Route", &self.send_route);
+        Self::print_hop("Route → Receive", &self.route_receive);
+        if self.send_route.is_empty() {
+            println!("  (no Route records — run via a router to see per-hop breakdown)");
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    zenoh::init_log_from_env_or("error");
+
+    println!(
+        "Collecting {} samples with Send+Route+Receive instrumentation...\n",
+        N_SAMPLES
+    );
+
+    let session = zenoh::open(Config::default()).await.unwrap();
+    let instr = TimestampInstrumentation::new(true, true, true).unwrap();
+
+    let acc: Arc<Mutex<HopAccumulator>> = Arc::new(Mutex::new(HopAccumulator::default()));
+    let acc2 = acc.clone();
+
+    let _sub = session
+        .declare_subscriber("demo/latency/**")
+        .callback(move |sample| {
+            if let Some(stack) = sample.timestamp_stack() {
+                acc2.lock().unwrap().ingest(stack);
+            }
+        })
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    for i in 0..N_SAMPLES {
+        session
+            .put(format!("demo/latency/{i}"), "payload")
+            .timestamp_instrumentation(Some(instr))
+            .await
+            .unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let received = acc.lock().unwrap().send_receive.len();
+    println!("Received {}/{} samples. Per-hop latency:\n", received, N_SAMPLES);
+    acc.lock().unwrap().print_stats();
+}

--- a/examples/examples/z_proprietary_token.rs
+++ b/examples/examples/z_proprietary_token.rs
@@ -1,0 +1,218 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+//! Demonstrates the proprietary 24-byte token pattern via `SessionTimestampCallback`.
+//!
+//! The token embeds hardware nanoseconds, a per-session sequence counter, a node
+//! fingerprint derived from the session ZenohId, and a checksum. Generic tooling sees
+//! `is_custom = true` and skips these records; only code that holds the `decode_token`
+//! function can extract timing data.
+//!
+//! This is the "data-layer moat" pattern: the wire transport is open source, but only
+//! the SDK that knows the proprietary format produces actionable analytics.
+//!
+//! In production, replace the additive checksum with HMAC-SHA256 (truncated to 4 bytes),
+//! keyed per customer deployment. That makes each record tamper-evident — a malicious
+//! intermediary node cannot forge a valid Send timestamp.
+//!
+//! Run with:
+//! ```
+//! cargo run --example z_proprietary_token --features unstable
+//! ```
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use zenoh::timestamp_stack::{
+    InstrumentationTimestamp, InterceptionPoint, SessionTimestampCallback,
+    TimestampInstrumentation, TsStackContext,
+};
+use zenoh::Config;
+
+// ── Token layout (24 bytes) ───────────────────────────────────────────────────
+// [ 0.. 8]  hardware_ns   u64 LE — wall-clock ns (swap for PTP clock in production)
+// [ 8..16]  sequence      u64 LE — monotonic per-session counter
+// [16..20]  fingerprint   4 bytes — first 4 bytes of session ZenohId (LE)
+// [20..24]  checksum      u32 LE — wrapping sum of bytes [0..20]
+//
+// PRODUCTION NOTE: bytes [20..24] should be HMAC-SHA256(key, bytes[0..20])[..4].
+// The key is provisioned per customer at SDK license issuance time.
+
+#[derive(Debug)]
+struct ProprietaryToken {
+    hardware_ns: u64,
+    sequence: u64,
+    node_fingerprint: [u8; 4],
+}
+
+fn build_callback() -> SessionTimestampCallback {
+    let seq = Arc::new(AtomicU64::new(0));
+    Arc::new(move |ctx: TsStackContext| {
+        let hardware_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        let sequence = seq.fetch_add(1, Ordering::Relaxed);
+        let zid_bytes = ctx.zid.to_le_bytes();
+
+        let mut buf = [0u8; 24];
+        buf[0..8].copy_from_slice(&hardware_ns.to_le_bytes());
+        buf[8..16].copy_from_slice(&sequence.to_le_bytes());
+        buf[16..20].copy_from_slice(&zid_bytes[..4]);
+        // additive checksum over the first 20 bytes
+        let checksum = buf[..20]
+            .iter()
+            .fold(0u32, |acc, &b| acc.wrapping_add(b as u32));
+        buf[20..24].copy_from_slice(&checksum.to_le_bytes());
+        buf.to_vec()
+    })
+}
+
+fn decode_token(bytes: &[u8]) -> Option<ProprietaryToken> {
+    if bytes.len() != 24 {
+        return None;
+    }
+    let expected = bytes[..20]
+        .iter()
+        .fold(0u32, |acc, &b| acc.wrapping_add(b as u32));
+    let stored = u32::from_le_bytes(bytes[20..24].try_into().ok()?);
+    if expected != stored {
+        return None; // tampered or wrong format
+    }
+    Some(ProprietaryToken {
+        hardware_ns: u64::from_le_bytes(bytes[0..8].try_into().ok()?),
+        sequence: u64::from_le_bytes(bytes[8..16].try_into().ok()?),
+        node_fingerprint: bytes[16..20].try_into().ok()?,
+    })
+}
+
+fn print_token_record(rec: &zenoh::timestamp_stack::TimestampStackRecord) {
+    match rec.timestamp() {
+        InstrumentationTimestamp::Custom(bytes) => match decode_token(bytes) {
+            Some(tok) => println!(
+                "  {:?}  custom  hw_ns={:<20}  seq={:<5}  node={:08x}",
+                rec.point(),
+                tok.hardware_ns,
+                tok.sequence,
+                u32::from_le_bytes(tok.node_fingerprint),
+            ),
+            None => println!("  {:?}  custom  [unrecognised format or tampered]", rec.point()),
+        },
+        InstrumentationTimestamp::UHLC(ts) => println!("  {:?}  hlc={}", rec.point(), ts),
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    zenoh::init_log_from_env_or("error");
+
+    println!("── Proprietary 24-byte token via SessionTimestampCallback ───────────────\n");
+
+    // ── Session with custom callback ──────────────────────────────────────────
+    let session = zenoh::open(Config::default())
+        .with_timestamp_callback(build_callback())
+        .await
+        .unwrap();
+
+    let instr = TimestampInstrumentation::new(true, false, true).unwrap();
+
+    let samples: Arc<Mutex<Vec<_>>> = Arc::new(Mutex::new(vec![]));
+    let samples2 = samples.clone();
+    let _sub = session
+        .declare_subscriber("demo/token/**")
+        .callback(move |s| samples2.lock().unwrap().push(s))
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    for i in 0..3u32 {
+        session
+            .put(format!("demo/token/{i}"), format!("message-{i}"))
+            .timestamp_instrumentation(Some(instr))
+            .await
+            .unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    println!("Received samples (decoded with proprietary format):\n");
+    for sample in samples.lock().unwrap().iter() {
+        let Some(stack) = sample.timestamp_stack() else {
+            continue;
+        };
+        println!("key: {}", sample.key_expr());
+        for rec in stack.records() {
+            print_token_record(rec);
+        }
+        println!();
+    }
+
+    // ── Demonstrate what generic tooling sees ─────────────────────────────────
+    println!("── What generic tooling sees (no decode key) ────────────────────────────\n");
+    for sample in samples.lock().unwrap().iter() {
+        let Some(stack) = sample.timestamp_stack() else {
+            continue;
+        };
+        println!("key: {}", sample.key_expr());
+        for rec in stack.records() {
+            match rec.timestamp() {
+                InstrumentationTimestamp::Custom(bytes) => println!(
+                    "  {:?}  is_custom=true  raw_bytes=[{}]  (skipped — unknown format)",
+                    rec.point(),
+                    bytes
+                        .iter()
+                        .take(8)
+                        .map(|b| format!("{b:02x}"))
+                        .collect::<Vec<_>>()
+                        .join(" "),
+                ),
+                InstrumentationTimestamp::UHLC(ts) => println!("  {:?}  hlc={}", rec.point(), ts),
+            }
+        }
+        println!();
+    }
+
+    // ── Side-by-side latency from custom timestamps ───────────────────────────
+    println!("── Send→Receive latency from proprietary hardware_ns field ─────────────\n");
+    {
+        let guard = samples.lock().unwrap();
+        let mut latencies: Vec<i64> = Vec::new();
+        for sample in guard.iter() {
+            let Some(stack) = sample.timestamp_stack() else {
+                continue;
+            };
+            let mut send_ns: Option<u64> = None;
+            let mut receive_ns: Option<u64> = None;
+            for rec in stack.records() {
+                let InstrumentationTimestamp::Custom(bytes) = rec.timestamp() else {
+                    continue;
+                };
+                if let Some(tok) = decode_token(bytes) {
+                    match rec.point() {
+                        InterceptionPoint::Send => send_ns = Some(tok.hardware_ns),
+                        InterceptionPoint::Receive => receive_ns = Some(tok.hardware_ns),
+                        _ => {}
+                    }
+                }
+            }
+            if let (Some(s), Some(r)) = (send_ns, receive_ns) {
+                latencies.push(r as i64 - s as i64);
+            }
+        }
+        for (i, lat_ns) in latencies.iter().enumerate() {
+            println!("  message-{i}  Send→Receive = {} µs", lat_ns / 1_000);
+        }
+    }
+}

--- a/examples/examples/z_proprietary_token.rs
+++ b/examples/examples/z_proprietary_token.rs
@@ -36,7 +36,7 @@ use std::time::Duration;
 
 use zenoh::timestamp_stack::{
     InstrumentationTimestamp, InterceptionPoint, SessionTimestampCallback,
-    TimestampInstrumentation, TsStackContext,
+    TimestampInstrumentationBuilder, TsStackContext,
 };
 use zenoh::Config;
 
@@ -125,7 +125,11 @@ async fn main() {
         .await
         .unwrap();
 
-    let instr = TimestampInstrumentation::new(true, false, true).unwrap();
+    let instr = TimestampInstrumentationBuilder::new()
+        .set_send(true)
+        .set_receive(true)
+        .build()
+        .unwrap();
 
     let samples: Arc<Mutex<Vec<_>>> = Arc::new(Mutex::new(vec![]));
     let samples2 = samples.clone();

--- a/examples/examples/z_timestamp_instrumentation.rs
+++ b/examples/examples/z_timestamp_instrumentation.rs
@@ -23,7 +23,7 @@
 
 use std::time::Duration;
 
-use zenoh::timestamp_stack::{InstrumentationTimestamp, TimestampInstrumentation};
+use zenoh::timestamp_stack::{InstrumentationTimestamp, TimestampInstrumentationBuilder};
 use zenoh::Config;
 
 fn ntp_to_ns(ntp: u64) -> u64 {
@@ -39,7 +39,12 @@ async fn main() {
     let session = zenoh::open(Config::default()).await.unwrap();
 
     // Enable Send + Route + Receive instrumentation.
-    let instr = TimestampInstrumentation::new(true, true, true).unwrap();
+    let instr = TimestampInstrumentationBuilder::new()
+        .set_send(true)
+        .set_route(true)
+        .set_receive(true)
+        .build()
+        .unwrap();
 
     let _sub = session
         .declare_subscriber("demo/timestamps/**")

--- a/examples/examples/z_timestamp_instrumentation.rs
+++ b/examples/examples/z_timestamp_instrumentation.rs
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2026 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+//! Demonstrates the `TsStack` timestamp instrumentation feature.
+//!
+//! Publishes a few messages with Send+Route+Receive instrumentation enabled
+//! and prints the per-message timestamp stack in the subscriber.
+//!
+//! Run with:
+//! ```
+//! cargo run --example z_timestamp_instrumentation --features unstable
+//! ```
+
+use std::time::Duration;
+
+use zenoh::timestamp_stack::{InstrumentationTimestamp, TimestampInstrumentation};
+use zenoh::Config;
+
+fn ntp_to_ns(ntp: u64) -> u64 {
+    let secs = ntp >> 32;
+    let frac = ntp & 0xFFFF_FFFF;
+    secs.saturating_mul(1_000_000_000) + ((frac * 1_000_000_000) >> 32)
+}
+
+#[tokio::main]
+async fn main() {
+    zenoh::init_log_from_env_or("error");
+
+    let session = zenoh::open(Config::default()).await.unwrap();
+
+    // Enable Send + Route + Receive instrumentation.
+    let instr = TimestampInstrumentation::new(true, true, true).unwrap();
+
+    let _sub = session
+        .declare_subscriber("demo/timestamps/**")
+        .callback(|sample| {
+            let Some(stack) = sample.timestamp_stack() else {
+                return;
+            };
+            println!("key: {}", sample.key_expr());
+            for rec in stack.records() {
+                match rec.timestamp() {
+                    InstrumentationTimestamp::UHLC(ts) => {
+                        let ns = ntp_to_ns(ts.get_time().as_u64());
+                        println!("  {:?}  hlc_ns={}", rec.point(), ns);
+                    }
+                    InstrumentationTimestamp::Custom(bytes) => {
+                        println!(
+                            "  {:?}  custom  {} bytes",
+                            rec.point(),
+                            bytes.len()
+                        );
+                    }
+                }
+            }
+            println!();
+        })
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    for i in 0..3u32 {
+        session
+            .put(format!("demo/timestamps/{i}"), format!("payload-{i}"))
+            .timestamp_instrumentation(Some(instr))
+            .await
+            .unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+}

--- a/zenoh-ext/src/advanced_publisher.rs
+++ b/zenoh-ext/src/advanced_publisher.rs
@@ -32,6 +32,7 @@ use zenoh::{
         },
         TerminatableTask,
     },
+    timestamp_stack::TimestampInstrumentation,
     key_expr::{keyexpr, KeyExpr},
     liveliness::LivelinessToken,
     pubsub::{
@@ -124,6 +125,8 @@ pub struct AdvancedPublisherBuilder<'a, 'b, 'c> {
     liveliness: bool,
     cache: bool,
     history: CacheConfig,
+    #[cfg(feature = "unstable")]
+    default_timestamp_instrumentation: Option<TimestampInstrumentation>,
 }
 
 #[zenoh_macros::unstable]
@@ -144,6 +147,10 @@ impl fmt::Debug for AdvancedPublisherBuilder<'_, '_, '_> {
             .field("liveliness", &self.liveliness)
             .field("cache", &self.cache)
             .field("history", &self.history)
+            .field(
+                "default_timestamp_instrumentation",
+                &self.default_timestamp_instrumentation,
+            )
             .finish()
     }
 }
@@ -167,6 +174,8 @@ impl<'a, 'b, 'c> AdvancedPublisherBuilder<'a, 'b, 'c> {
             liveliness: false,
             cache: false,
             history: CacheConfig::default(),
+            #[cfg(feature = "unstable")]
+            default_timestamp_instrumentation: None,
         }
     }
 
@@ -286,6 +295,24 @@ impl QoSBuilderTrait for AdvancedPublisherBuilder<'_, '_, '_> {
 }
 
 #[zenoh_macros::unstable]
+impl<'a, 'b, 'c> AdvancedPublisherBuilder<'a, 'b, 'c> {
+    /// Sets a default [`TimestampInstrumentation`] applied to every `put`/`delete` from this publisher.
+    ///
+    /// Can be overridden per-put via
+    /// [`AdvancedPublicationBuilder::timestamp_instrumentation`].
+    #[zenoh_macros::unstable]
+    pub fn timestamp_instrumentation(
+        self,
+        instrumentation: Option<TimestampInstrumentation>,
+    ) -> Self {
+        Self {
+            default_timestamp_instrumentation: instrumentation,
+            ..self
+        }
+    }
+}
+
+#[zenoh_macros::unstable]
 impl<'b> Resolvable for AdvancedPublisherBuilder<'_, 'b, '_> {
     type To = ZResult<AdvancedPublisher<'b>>;
 }
@@ -348,6 +375,8 @@ pub struct AdvancedPublisher<'a> {
     cache: Option<AdvancedCache>,
     _token: Option<LivelinessToken>,
     _state_publisher: Option<TerminatableTask>,
+    #[cfg(feature = "unstable")]
+    default_timestamp_instrumentation: Option<TimestampInstrumentation>,
 }
 
 #[zenoh_macros::unstable]
@@ -506,6 +535,8 @@ impl<'a> AdvancedPublisher<'a> {
             cache,
             _token: token,
             _state_publisher: state_publisher,
+            #[cfg(feature = "unstable")]
+            default_timestamp_instrumentation: conf.default_timestamp_instrumentation,
         })
     }
 
@@ -590,6 +621,10 @@ impl<'a> AdvancedPublisher<'a> {
         if let Some(hlc) = self.publisher.session().hlc() {
             builder = builder.timestamp(hlc.new_timestamp());
         }
+        #[cfg(feature = "unstable")]
+        if self.default_timestamp_instrumentation.is_some() {
+            builder = builder.timestamp_instrumentation(self.default_timestamp_instrumentation);
+        }
         AdvancedPublisherPutBuilder {
             builder,
             cache: self.cache.as_ref(),
@@ -622,6 +657,10 @@ impl<'a> AdvancedPublisher<'a> {
         }
         if let Some(hlc) = self.publisher.session().hlc() {
             builder = builder.timestamp(hlc.new_timestamp());
+        }
+        #[cfg(feature = "unstable")]
+        if self.default_timestamp_instrumentation.is_some() {
+            builder = builder.timestamp_instrumentation(self.default_timestamp_instrumentation);
         }
         AdvancedPublisherDeleteBuilder {
             builder,

--- a/zenoh/src/api/builders/session.rs
+++ b/zenoh/src/api/builders/session.rs
@@ -28,7 +28,7 @@ use zenoh_shm::api::client_storage::ShmClientStorage;
 
 use crate::api::session::Session;
 #[cfg(feature = "unstable")]
-use crate::api::timestamp_stack::GetTimestampCallback;
+use crate::api::timestamp_stack::SessionTimestampCallback;
 #[cfg(feature = "internal")]
 use crate::net::runtime::DynamicRuntime;
 
@@ -52,7 +52,7 @@ where
     #[cfg(feature = "shared-memory")]
     shm_clients: Option<Arc<ShmClientStorage>>,
     #[cfg(feature = "unstable")]
-    timestamp_callback: Option<GetTimestampCallback>,
+    timestamp_callback: Option<SessionTimestampCallback>,
 }
 
 impl<TryIntoConfig> fmt::Debug for OpenBuilder<TryIntoConfig>
@@ -115,8 +115,8 @@ where
     ///
     /// If no callback is provided, the default UHLC timestamp generation will be used.
     #[zenoh_macros::unstable]
-    pub fn with_timestamp_callback(mut self, cb: impl Into<GetTimestampCallback>) -> Self {
-        self.timestamp_callback = Some(cb.into());
+    pub fn with_timestamp_callback(mut self, cb: SessionTimestampCallback) -> Self {
+        self.timestamp_callback = Some(cb);
         self
     }
 }

--- a/zenoh/src/api/session.rs
+++ b/zenoh/src/api/session.rs
@@ -77,7 +77,7 @@ use crate::api::timestamp_stack::TimestampInstrumentation;
 #[cfg(feature = "unstable")]
 use crate::api::{
     cancellation::CancellationToken, sample::SourceInfo, selector::ZenohParameters,
-    timestamp_stack::GetTimestampCallback,
+    timestamp_stack::SessionTimestampCallback,
 };
 #[cfg(feature = "internal")]
 use crate::net::runtime::Runtime;
@@ -1451,7 +1451,7 @@ impl Session {
     pub(super) fn new(
         config: Config,
         #[cfg(feature = "shared-memory")] shm_clients: Option<Arc<ShmClientStorage>>,
-        #[cfg(feature = "unstable")] timestamp_callback: Option<GetTimestampCallback>,
+        #[cfg(feature = "unstable")] timestamp_callback: Option<SessionTimestampCallback>,
     ) -> impl Resolve<ZResult<Session>> {
         ResolveFuture::new(async move {
             tracing::debug!("Config: {:?}", &config);

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -37,12 +37,16 @@ pub struct TsStackContext {
     pub interception_point: InterceptionPoint,
 }
 
-/// Type alias for the user-defined timestamp callback.
+/// Session-level callback for generating custom timestamps.
+///
+/// Registered once at [`zenoh::open`](crate::open) time via
+/// [`OpenBuilder::with_timestamp_callback`](crate::session::OpenBuilder::with_timestamp_callback)
+/// and applied to every instrumented message on that session.
 ///
 /// The callback receives a [`TsStackContext`] and returns the raw timestamp bytes
-/// to be pushed onto the timestamp stack.
+/// to be pushed onto the stack. Return an empty `Vec` to skip stamping this point.
 #[zenoh_macros::unstable]
-pub type GetTimestampCallback = Arc<dyn Fn(TsStackContext) -> Vec<u8> + Send + Sync>;
+pub type SessionTimestampCallback = Arc<dyn Fn(TsStackContext) -> Vec<u8> + Send + Sync>;
 
 /// Identifies which interception point a timestamp record was captured at.
 ///

--- a/zenoh/src/api/timestamp_stack.rs
+++ b/zenoh/src/api/timestamp_stack.rs
@@ -28,6 +28,7 @@ use crate::{net::runtime::IRuntime, session::ZenohId};
 /// The struct is `#[non_exhaustive]` to allow adding new fields in the future.
 #[non_exhaustive]
 #[zenoh_macros::unstable]
+#[derive(Debug, Clone)]
 pub struct TsStackContext {
     /// The Zenoh ID of the current node.
     pub zid: ZenohId,

--- a/zenoh/src/lib.rs
+++ b/zenoh/src/lib.rs
@@ -1188,7 +1188,7 @@ pub mod shm {
 #[zenoh_macros::unstable]
 pub mod timestamp_stack {
     pub use crate::api::timestamp_stack::{
-        GetTimestampCallback, InstrumentationTimestamp, InterceptionPoint,
+        SessionTimestampCallback, InstrumentationTimestamp, InterceptionPoint,
         TimestampInstrumentation, TimestampInstrumentationBuilder, TimestampStack,
         TimestampStackRecord, TsStackContext,
     };

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -290,7 +290,7 @@ impl IRuntime for RuntimeState {
         use zenoh_codec::{WCodec, Zenoh080};
         let mut buf = Vec::new();
         if let Err(e) = Zenoh080.write(&mut buf, &ts) {
-            tracing::warn!("Failed to serialize HLC timestamp for TsStack: {e} — skipping");
+            tracing::warn!("Failed to serialize HLC timestamp for TsStack: {e:?} — skipping");
             return (Vec::new(), false);
         }
         (buf, false)

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -289,7 +289,8 @@ impl IRuntime for RuntimeState {
 
         use zenoh_codec::{WCodec, Zenoh080};
         let mut buf = Vec::new();
-        if Zenoh080.write(&mut buf, &ts).is_err() {
+        if let Err(e) = Zenoh080.write(&mut buf, &ts) {
+            tracing::warn!("Failed to serialize HLC timestamp for TsStack: {e} — skipping");
             return (Vec::new(), false);
         }
         (buf, false)

--- a/zenoh/src/net/runtime/mod.rs
+++ b/zenoh/src/net/runtime/mod.rs
@@ -90,7 +90,7 @@ use crate::api::loader::{load_plugins, start_plugins};
 #[cfg(feature = "plugins")]
 use crate::api::plugins::PluginsManager;
 #[cfg(feature = "unstable")]
-use crate::api::timestamp_stack::{GetTimestampCallback, TsStackContext};
+use crate::api::timestamp_stack::{SessionTimestampCallback, TsStackContext};
 #[cfg(feature = "internal")]
 use crate::session::CloseBuilder;
 use crate::{
@@ -181,7 +181,7 @@ pub(crate) struct RuntimeState {
     #[cfg(feature = "unstable")]
     lazy_hlc: OnceLock<Arc<HLC>>,
     #[cfg(feature = "unstable")]
-    timestamp_callback: Option<GetTimestampCallback>,
+    timestamp_callback: Option<SessionTimestampCallback>,
     task_controller: TaskController,
     #[cfg(feature = "plugins")]
     plugins_manager: Mutex<PluginsManager>,
@@ -642,7 +642,7 @@ pub struct RuntimeBuilder {
     #[cfg(feature = "shared-memory")]
     shm_clients: Option<Arc<ShmClientStorage>>,
     #[cfg(feature = "unstable")]
-    timestamp_callback: Option<GetTimestampCallback>,
+    timestamp_callback: Option<SessionTimestampCallback>,
     #[cfg(test)]
     subregions: Option<Vec<Region>>,
     #[cfg(test)]
@@ -701,7 +701,7 @@ impl RuntimeBuilder {
     }
 
     #[cfg(feature = "unstable")]
-    pub fn timestamp_callback(mut self, cb: Option<GetTimestampCallback>) -> Self {
+    pub fn timestamp_callback(mut self, cb: Option<SessionTimestampCallback>) -> Self {
         self.timestamp_callback = cb;
         self
     }

--- a/zenoh/tests/timestamp_instrumentation.rs
+++ b/zenoh/tests/timestamp_instrumentation.rs
@@ -20,7 +20,7 @@ use zenoh::{
     config::WhatAmI,
     query::ConsolidationMode,
     timestamp_stack::{
-        GetTimestampCallback, InstrumentationTimestamp, InterceptionPoint,
+        SessionTimestampCallback, InstrumentationTimestamp, InterceptionPoint,
         TimestampInstrumentation, TimestampInstrumentationBuilder,
     },
 };
@@ -1380,7 +1380,7 @@ async fn custom_callback_pub_sub() {
     zenoh_util::init_log_from_env_or("error");
     let ke = "test/ts_instr/custom_callback/pub_sub";
     let custom_bytes = b"custom_ts_123".to_vec();
-    let cb: GetTimestampCallback = Arc::new(move |_ctx| custom_bytes.clone());
+    let cb: SessionTimestampCallback = Arc::new(move |_ctx| custom_bytes.clone());
 
     let instr = make_instrumentation(true, false, false);
 
@@ -1415,8 +1415,8 @@ async fn custom_callback_query_reply() {
     let custom_bytes_query = b"custom_query_ts".to_vec();
     let custom_bytes_reply = b"custom_reply_ts".to_vec();
 
-    let cb_query: GetTimestampCallback = Arc::new(move |_ctx| custom_bytes_query.clone());
-    let cb_reply: GetTimestampCallback = Arc::new(move |_ctx| custom_bytes_reply.clone());
+    let cb_query: SessionTimestampCallback = Arc::new(move |_ctx| custom_bytes_query.clone());
+    let cb_reply: SessionTimestampCallback = Arc::new(move |_ctx| custom_bytes_reply.clone());
 
     let instr = make_instrumentation(true, false, true);
 
@@ -1504,7 +1504,7 @@ async fn custom_callback_context() {
     };
     let capture_clone = capture.clone();
 
-    let cb: GetTimestampCallback = Arc::new(move |ctx| {
+    let cb: SessionTimestampCallback = Arc::new(move |ctx| {
         capture_clone
             .contexts
             .lock()


### PR DESCRIPTION
## Summary

Adds opt-in timestamp instrumentation for measuring end-to-end message latency in Zenoh. Messages can carry a `TsStack` wire extension that accumulates `Interception` records at up to three points along a message's path: **Send**, **Route**, and **Receive**.

The feature is entirely `#[cfg(feature = "unstable")]`-gated. Uninstrumented messages carry zero overhead — `push_ts_interception` is a no-op when `ext_ts_stack` is `None`.

## Sister PRs

| Binding | Branch | Status |
|---------|--------|--------|
| Python | https://github.com/YuanYuYuan/zenoh-python/pull/1 | CI passing |
| C | https://github.com/YuanYuYuan/zenoh-c/pull/1 | CI passing |

---

## API Design

### Rust (`zenoh` crate, `feature = "unstable"`)

All public types live in `zenoh::timestamp_stack`.

**Configuring instrumentation** — choose which points to record per-message:

```rust
let instr = TimestampInstrumentationBuilder::new()
    .set_send(true)
    .set_receive(true)
    .build()?;
```

**Session-level custom clock** — registered once at open time, applied to every instrumented message:

```rust
let cb: SessionTimestampCallback = Arc::new(|ctx: TsStackContext| {
    // ctx.zid, ctx.whatami, ctx.interception_point are available
    my_clock_bytes()
});
let session = zenoh::open(Config::default())
    .with_timestamp_callback(cb)
    .await?;
```

`SessionTimestampCallback` is `Arc<dyn Fn(TsStackContext) -> Vec<u8> + Send + Sync>`. Returning an empty `Vec` skips stamping that point. When no callback is registered, Zenoh uses a lazily-initialized UHLC.

**Attaching instrumentation** — `timestamp_instrumentation(Option<TimestampInstrumentation>)` is available on:

```rust
session.put(key, payload).timestamp_instrumentation(Some(instr)).await?;
session.get(selector).timestamp_instrumentation(Some(instr)).await?;
queryable_builder.reply(key, payload).timestamp_instrumentation(Some(instr)).await?;
session.declare_publisher(key).timestamp_instrumentation(Some(instr)).await?;
publisher.put(payload).timestamp_instrumentation(Some(instr)).await?; // per-put override
```

**Reading timestamps** off a received `Sample`, `ReplyError`, or `Query`:

```rust
if let Some(stack) = sample.timestamp_stack() {
    for rec in stack.records() {
        match rec.timestamp() {
            InstrumentationTimestamp::UHLC(ts) => { /* standard uhlc::Timestamp */ }
            InstrumentationTimestamp::Custom(bytes) => { /* custom-callback bytes */ }
        }
    }
}
```

`TimestampStack::records()` returns records in wire order (Send → Route(s) → Receive). `rec.is_custom()` is a convenience predicate over the enum variant.

**`AdvancedPublisher` (`zenoh-ext`):**

```rust
let publisher = session
    .declare_advanced_publisher(key)
    .timestamp_instrumentation(Some(instr))      // default for all puts
    .await?;
publisher.put(payload)
    .timestamp_instrumentation(Some(send_only))  // per-put override
    .await?;
```

---

### Python (`zenoh-python`)

All types are importable directly from `zenoh`:

```python
from zenoh import InterceptionPoint, TimestampInstrumentation
```

**Configuring instrumentation:**

```python
instr = TimestampInstrumentation(send=True, receive=True)
instr = TimestampInstrumentation(send=True, route=True, receive=True)
```

**Session-level custom clock:**

```python
def my_clock(ctx):           # ctx.zid, ctx.whatami, ctx.interception_point
    return struct.pack("<Q", time.time_ns())

with zenoh.open(zenoh.Config(), timestamp_callback=my_clock) as session:
    ...
```

**Attaching instrumentation** — `timestamp_instrumentation=` kwarg on:

```python
session.put(key, payload, timestamp_instrumentation=instr)
session.get(selector, timestamp_instrumentation=instr)
query.reply(key, payload, timestamp_instrumentation=instr)
query.reply_err(err_payload, timestamp_instrumentation=instr)
session.declare_publisher(key, timestamp_instrumentation=instr)  # publisher default
pub.put(payload, timestamp_instrumentation=send_only)            # per-put override
```

**Reading timestamps:**

```python
stack = sample.timestamp_stack      # None if not instrumented
if stack:
    for rec in stack.records:
        ts = rec.as_timestamp()     # Timestamp | None  (None for custom-callback records)
        raw = rec.timestamp()       # bytes | None  (bytes for custom-callback records only)
```

`InterceptionPoint` is a pyclass enum with values `SEND`, `ROUTE`, `RECEIVE`, `UNKNOWN`.

---

### C (`zenoh-c`, `ZENOHC_BUILD_WITH_UNSTABLE_API=ON`)

**Types:**

| C type | Purpose |
|--------|---------|
| `z_owned_timestamp_instrumentation_t` / `z_loaned_timestamp_instrumentation_t` | instrumentation config |
| `z_interception_point_t` | enum: `Z_INTERCEPTION_POINT_SEND`, `Z_INTERCEPTION_POINT_ROUTE`, `Z_INTERCEPTION_POINT_RECEIVE`, `Z_INTERCEPTION_POINT_UNKNOWN` |
| `z_loaned_timestamp_stack_t` | stack carried by a received message |
| `z_loaned_timestamp_stack_record_t` | a single interception record |
| `z_owned_session_ts_callback_t` / `z_moved_session_ts_callback_t` | session-level custom clock |

**Configuring instrumentation:**

```c
z_owned_timestamp_instrumentation_t instr;
z_timestamp_instrumentation_new(&instr, /*send=*/true, /*route=*/false, /*receive=*/true);
// ...use...
z_timestamp_instrumentation_drop(z_timestamp_instrumentation_move(&instr));
```

**Session-level custom clock:**

```c
z_owned_session_ts_callback_t cb;
z_closure_session_ts_callback(&cb, my_callback_fn, my_drop_fn, my_context);

z_open_options_t opts = z_open_options_default();
opts.timestamp_callback = z_session_ts_callback_move(&cb);
z_open(&session, z_config_move(&config), &opts);
```

**Attaching instrumentation** — `timestamp_instrumentation` field on the relevant `_options_t` struct:

```c
z_put_options_t opts = z_put_options_default();
opts.timestamp_instrumentation = z_timestamp_instrumentation_loan(&instr);
z_put(z_session_loan(&session), z_view_keyexpr_loan(&ke), z_bytes_move(&payload), &opts);
```

**Reading timestamps:**

```c
const z_loaned_timestamp_stack_t* stack = z_sample_timestamp_stack(sample);
if (stack) {
    size_t n = z_timestamp_stack_record_count(stack);
    for (size_t i = 0; i < n; i++) {
        const z_loaned_timestamp_stack_record_t* rec = z_timestamp_stack_record_at(stack, i);
        bool custom = z_timestamp_stack_record_is_custom(rec);
        if (custom) {
            size_t len;
            const uint8_t* bytes = z_timestamp_stack_record_timestamp(rec, &len);
        } else {
            z_timestamp_t ts;
            z_timestamp_stack_record_as_timestamp(rec, &ts);
        }
    }
}
```

---

## Wire Protocol

A new `TsStack` extension (ID `0x7`) is added to `Push`, `Request`, and `Response` messages. It carries:

- `conf_flags` — bitmask of enabled interception points (set by the sender, unchanged in transit)
- `stack` — ordered `Vec<Interception>`, each with a `flags` byte (point ID + `IS_CUSTOM_TS` bit) and a length-prefixed `timestamp` byte vector

The codec bounds `timestamp` bytes to `u16::MAX` (65 535) and caps stack depth at 64 to prevent memory exhaustion from crafted wire input.

---

## Implementation Points

- **Send**: `session.rs` (`resolve_put`, `resolve_get`) and `builders/reply.rs`
- **Route**: `routing/dispatcher/pubsub.rs` per-subscriber (inside fan-out loop) and `queries.rs`
- **Receive**: `WeakSession::send_push_consume` and `adminspace.rs`

Route stamping happens inside the per-subscriber loop so each subscriber gets a timestamp that reflects queueing delay up to that point in fan-out.

---

## Tests

- **20 integration tests** in `zenoh/tests/timestamp_stack.rs`: no-instrumentation baseline, single-point (Send / Receive), all-points ordering, custom callback byte verification, callback context correctness, per-message stack independence, query/reply flows, `is_custom` flag, route-only instrumentation, `ReplyError` propagation, multiple-subscriber fan-out, and publisher API path
- **49 integration tests** in `zenoh/tests/timestamp_instrumentation.rs`: full pub/sub lifecycle, multiple-session scenarios, callback interaction with instrumentation flags, and end-to-end latency measurement flows
- **4 codec tests**: empty stack, known records, random round-trips, and the 64-depth limit

All 73 tests pass on Rust 1.93.0.

---

## Breaking Changes

None. All new types and methods are behind `feature = "unstable"`.

## Robustness Notes

- `get_ts_stack_timestamp` no longer panics on UHLC serialization failure: the `expect()` was replaced with a `tracing::warn!` and graceful empty return.
- `push_ts_interception` uses `debug_assert!` + silent skip for unknown point IDs.
- Codec decode caps at 64 interceptions and `u16::MAX` bytes per timestamp to prevent memory exhaustion from crafted wire input.

## Known Limitations

- Route timestamp is stamped once per routing hop; multi-hop topologies produce multiple ROUTE records (by design)
- `QueryCleanup` timeout responses carry `ext_ts_stack: None` — not instrumented (rationale documented in code)

<!-- 🏷️ Label-Based Checklist START -->

---
## 🏷️ Label-Based Checklist

Based on the labels applied to this PR, please complete these additional requirements:

**Labels:** `new feature`

## 🆕 New Feature Requirements

Since this PR adds a new feature:

- [x] **Feature scope documented** - Clear description of what the feature does and why it's needed
- [x] **Minimum necessary code** - Implementation is as simple as possible, doesn't overcomplicate the system
- [x] **New APIs well-designed** - Public APIs are intuitive, consistent with existing APIs
- [x] **Comprehensive tests** - All functionality is tested (happy path + edge cases + error cases)
- [x] **Examples provided** - `examples/z_timestamp_instrumentation.rs` added
- [ ] **Documentation added** - New docs explaining the feature, its use cases, and API
- [x] **Feature flag considered** - Entirely behind `feature = "unstable"`, zero overhead when inactive
- [x] **Performance impact assessed** - No overhead on uninstrumented messages (`push_ts_interception` is a no-op when `ext_ts_stack` is `None`)
- [x] **Integration tested** - 73/73 integration + codec tests pass (Rust 1.93.0)

**Consider:** Can this feature be split into smaller, incremental PRs?

**Instructions:**
1. Check off items as you complete them (change `- [ ]` to `- [x]`)
2. The PR checklist CI will verify these are completed

*This checklist updates automatically when labels change, but preserves your checked boxes.*

<!-- 🏷️ Label-Based Checklist END -->