### PR TITLE
refactor(ci): dedupe fuzz coverage steps into composite action

### DIFF
--- a/.github/actions/fuzz-coverage/action.yml
+++ b/.github/actions/fuzz-coverage/action.yml
@@ -1,0 +1,107 @@
+#
+# Copyright (c) 2026 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+#
+name: Fuzz coverage report
+description: >
+  Run cargo-fuzz coverage for a target, publish an llvm-cov summary to the
+  job summary, and upload the coverage artifacts.
+
+inputs:
+  working-directory:
+    description: Directory containing the fuzz crate (relative to repo root)
+    required: true
+  target:
+    description: Fuzz target name
+    required: true
+  toolchain:
+    description: Rust toolchain to run cargo-fuzz/llvm-cov with
+    required: true
+  source-paths:
+    description: Newline-separated list of source paths (relative to working-directory) to restrict the report to
+    required: true
+  title:
+    description: Human-readable title used in the job summary heading (e.g. "Codec fuzz", "Protocol fuzz")
+    required: true
+  artifact-prefix:
+    description: Prefix used in the uploaded artifact name (e.g. "codec", "protocol")
+    required: true
+  label:
+    description: Fuzzing profile label (daily/weekly), used in the artifact name
+    required: true
+  ignore-filename-regex:
+    description: --ignore-filename-regex value passed to llvm-cov
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Generate coverage report
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+
+        target="${{ inputs.target }}"
+        cargo +${{ inputs.toolchain }} fuzz coverage -s none "$target" "corpus/$target"
+
+        llvm_bin="$(dirname "$(rustc +${{ inputs.toolchain }} --print target-libdir)")/bin"
+        host_triple="$(rustc +${{ inputs.toolchain }} -vV | sed -n 's/^host: //p')"
+        binary="target/${host_triple}/coverage/${host_triple}/release/${target}"
+        profdata="coverage/${target}/coverage.profdata"
+        report_dir="coverage/${target}/html"
+        report_txt="coverage/${target}/report.txt"
+
+        source_paths=()
+        while IFS= read -r path; do
+          [ -n "$path" ] && source_paths+=("$path")
+        done <<< "${{ inputs.source-paths }}"
+
+        "$llvm_bin/llvm-cov" report "$binary" \
+          -instr-profile="$profdata" \
+          --ignore-filename-regex="${{ inputs.ignore-filename-regex }}" \
+          "${source_paths[@]}" | tee "$report_txt"
+
+        "$llvm_bin/llvm-cov" show "$binary" \
+          -instr-profile="$profdata" \
+          --format=html \
+          --output-dir="$report_dir" \
+          --ignore-filename-regex="${{ inputs.ignore-filename-regex }}" \
+          "${source_paths[@]}"
+
+    - name: Publish coverage summary
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+
+        target="${{ inputs.target }}"
+        report_txt="coverage/${target}/report.txt"
+
+        {
+          echo "## ${{ inputs.title }} coverage: \`$target\`"
+          echo
+          echo "<details><summary>Full llvm-cov report</summary>"
+          echo
+          echo '```text'
+          cat "$report_txt"
+          echo '```'
+          echo "</details>"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload coverage artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: fuzz-coverage-${{ inputs.artifact-prefix }}-${{ inputs.label }}-${{ inputs.target }}
+        path: ${{ inputs.working-directory }}/coverage/${{ inputs.target }}
+        if-no-files-found: error
+        retention-days: 14

--- a/.github/workflows/fuzz-scheduled.yml
+++ b/.github/workflows/fuzz-scheduled.yml
@@ -108,64 +108,19 @@ jobs:
         working-directory: commons/zenoh-codec/fuzz
 
       - name: Generate codec coverage report
-        shell: bash
-        working-directory: commons/zenoh-codec/fuzz
-        run: |
-          set -euo pipefail
-
-          target="${{ matrix.target }}"
-          cargo +${{ env.NIGHTLY_TOOLCHAIN }} fuzz coverage -s none "$target" "corpus/$target"
-
-          llvm_bin="$(dirname "$(rustc +${{ env.NIGHTLY_TOOLCHAIN }} --print target-libdir)")/bin"
-          host_triple="$(rustc +${{ env.NIGHTLY_TOOLCHAIN }} -vV | sed -n 's/^host: //p')"
-          binary="target/${host_triple}/coverage/${host_triple}/release/${target}"
-          profdata="coverage/${target}/coverage.profdata"
-          report_dir="coverage/${target}/html"
-          report_txt="coverage/${target}/report.txt"
-
-          "$llvm_bin/llvm-cov" report "$binary" \
-            -instr-profile="$profdata" \
-            --ignore-filename-regex="${{ env.COVERAGE_IGNORE_FILENAME_REGEX }}" \
-            ../src \
-            ../../zenoh-protocol/src \
-            ../../zenoh-buffers/src | tee "$report_txt"
-
-          "$llvm_bin/llvm-cov" show "$binary" \
-            -instr-profile="$profdata" \
-            --format=html \
-            --output-dir="$report_dir" \
-            --ignore-filename-regex="${{ env.COVERAGE_IGNORE_FILENAME_REGEX }}" \
-            ../src \
-            ../../zenoh-protocol/src \
-            ../../zenoh-buffers/src
-
-      - name: Publish codec coverage summary
-        shell: bash
-        working-directory: commons/zenoh-codec/fuzz
-        run: |
-          set -euo pipefail
-
-          target="${{ matrix.target }}"
-          report_txt="coverage/${target}/report.txt"
-
-          {
-            echo "## Codec fuzz coverage: \`$target\`"
-            echo
-            echo "<details><summary>Full llvm-cov report</summary>"
-            echo
-            echo '```text'
-            cat "$report_txt"
-            echo '```'
-            echo "</details>"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload codec coverage artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: ./.github/actions/fuzz-coverage
         with:
-          name: fuzz-coverage-codec-${{ needs.determine-profile.outputs.label }}-${{ matrix.target }}
-          path: commons/zenoh-codec/fuzz/coverage/${{ matrix.target }}
-          if-no-files-found: error
-          retention-days: 14
+          working-directory: commons/zenoh-codec/fuzz
+          target: ${{ matrix.target }}
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+          source-paths: |
+            ../src
+            ../../zenoh-protocol/src
+            ../../zenoh-buffers/src
+          title: Codec fuzz
+          artifact-prefix: codec
+          label: ${{ needs.determine-profile.outputs.label }}
+          ignore-filename-regex: ${{ env.COVERAGE_IGNORE_FILENAME_REGEX }}
 
       - name: Upload codec fuzz artifacts
         if: failure()
@@ -178,6 +133,7 @@ jobs:
 
       - name: Cleanup profraw files
         if: always()
+        working-directory: commons/zenoh-codec/fuzz
         run: find . -name "*.profraw" -type f -delete
 
   fuzz-protocol:
@@ -218,62 +174,18 @@ jobs:
         working-directory: commons/zenoh-protocol/fuzz
 
       - name: Generate protocol coverage report
-        shell: bash
-        working-directory: commons/zenoh-protocol/fuzz
-        run: |
-          set -euo pipefail
-
-          target="endpoint_from_str"
-          cargo +${{ env.NIGHTLY_TOOLCHAIN }} fuzz coverage -s none "$target" "corpus/$target"
-
-          llvm_bin="$(dirname "$(rustc +${{ env.NIGHTLY_TOOLCHAIN }} --print target-libdir)")/bin"
-          host_triple="$(rustc +${{ env.NIGHTLY_TOOLCHAIN }} -vV | sed -n 's/^host: //p')"
-          binary="target/${host_triple}/coverage/${host_triple}/release/${target}"
-          profdata="coverage/${target}/coverage.profdata"
-          report_dir="coverage/${target}/html"
-          report_txt="coverage/${target}/report.txt"
-
-          "$llvm_bin/llvm-cov" report "$binary" \
-            -instr-profile="$profdata" \
-            --ignore-filename-regex="${{ env.COVERAGE_IGNORE_FILENAME_REGEX }}" \
-            ../src/core/endpoint.rs \
-            ../src/core/parameters.rs | tee "$report_txt"
-
-          "$llvm_bin/llvm-cov" show "$binary" \
-            -instr-profile="$profdata" \
-            --format=html \
-            --output-dir="$report_dir" \
-            --ignore-filename-regex="${{ env.COVERAGE_IGNORE_FILENAME_REGEX }}" \
-            ../src/core/endpoint.rs \
-            ../src/core/parameters.rs
-
-      - name: Publish protocol coverage summary
-        shell: bash
-        working-directory: commons/zenoh-protocol/fuzz
-        run: |
-          set -euo pipefail
-
-          target="endpoint_from_str"
-          report_txt="coverage/${target}/report.txt"
-
-          {
-            echo "## Protocol fuzz coverage: \`$target\`"
-            echo
-            echo "<details><summary>Full llvm-cov report</summary>"
-            echo
-            echo '```text'
-            cat "$report_txt"
-            echo '```'
-            echo "</details>"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload protocol coverage artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: ./.github/actions/fuzz-coverage
         with:
-          name: fuzz-coverage-protocol-${{ needs.determine-profile.outputs.label }}-endpoint_from_str
-          path: commons/zenoh-protocol/fuzz/coverage/endpoint_from_str
-          if-no-files-found: error
-          retention-days: 14
+          working-directory: commons/zenoh-protocol/fuzz
+          target: endpoint_from_str
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+          source-paths: |
+            ../src/core/endpoint.rs
+            ../src/core/parameters.rs
+          title: Protocol fuzz
+          artifact-prefix: protocol
+          label: ${{ needs.determine-profile.outputs.label }}
+          ignore-filename-regex: ${{ env.COVERAGE_IGNORE_FILENAME_REGEX }}
 
       - name: Upload protocol fuzz artifacts
         if: failure()
@@ -286,4 +198,5 @@ jobs:
 
       - name: Cleanup profraw files
         if: always()
+        working-directory: commons/zenoh-protocol/fuzz
         run: find . -name "*.profraw" -type f -delete


### PR DESCRIPTION
## Summary
- Extract the near-identical codec/protocol fuzz coverage report generation, summary publishing, and artifact upload steps into a shared `.github/actions/fuzz-coverage` composite action, parameterized by working directory, target, source paths, title, and artifact prefix.
- Scope the profraw cleanup step's `working-directory` to match its sibling steps in each job, instead of running from the job's default root.

## Motivation
The two coverage blocks in `fuzz-scheduled.yml` were copy-pasted verbatim aside from target name and source paths. A future fix to the llvm-cov invocation applied to only one copy would silently leave the other stale.